### PR TITLE
Added bearerType option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,6 +44,7 @@ When registering the plugin you must specify a configuration object:
 sent to the client (optional)
 * `contentType`: If the content to be sent is anything other than
 `application/json`, then the `contentType` property must be set (optional)
+* `bearerType`: string specifying the Bearer string (optional)
 
 The default configuration object is:
 
@@ -51,6 +52,7 @@ The default configuration object is:
   {
     keys: new Set(),
     contentType: undefined,
+    bearerType: 'Bearer'
     errorResponse: (err) => {
       return {error: err.message}
     }

--- a/Readme.md
+++ b/Readme.md
@@ -52,7 +52,7 @@ The default configuration object is:
   {
     keys: new Set(),
     contentType: undefined,
-    bearerType: 'Bearer'
+    bearerType: 'Bearer',
     errorResponse: (err) => {
       return {error: err.message}
     }

--- a/plugin.js
+++ b/plugin.js
@@ -9,7 +9,8 @@ function factory (options) {
     errorResponse (err) {
       return { error: err.message }
     },
-    contentType: undefined
+    contentType: undefined,
+    bearerType: 'Bearer'
   }
   const _options = Object.assign({}, defaultOptions, options || {})
   if (_options.keys instanceof Set) _options.keys = Array.from(_options.keys)
@@ -25,7 +26,7 @@ function factory (options) {
       return
     }
 
-    const key = header.substring(6).trim()
+    const key = header.substring(bearerType.length).trim()
     if (authenticate(keys, key) === undefined) {
       const invalidKeyError = Error('invalid authorization header')
       fastifyReq.log.error('invalid authorization header: `%s`', header)

--- a/plugin.js
+++ b/plugin.js
@@ -14,7 +14,7 @@ function factory (options) {
   }
   const _options = Object.assign({}, defaultOptions, options || {})
   if (_options.keys instanceof Set) _options.keys = Array.from(_options.keys)
-  const { keys, errorResponse, contentType } = _options
+  const { keys, errorResponse, contentType, bearerType } = _options
 
   function bearerAuthHook (fastifyReq, fastifyRes, next) {
     const header = fastifyReq.req.headers['authorization']

--- a/test/hook.test.js
+++ b/test/hook.test.js
@@ -5,6 +5,8 @@ const noop = () => {}
 const plugin = require('../').internals.factory
 const key = '123456789012354579814'
 const keys = { keys: new Set([key]) }
+const bearerAlt = 'BearerAlt'
+const keysAlt = { keys: new Set([key]), bearerType: bearerAlt }
 
 test('hook rejects for missing header', (t) => {
   t.plan(2)
@@ -92,6 +94,30 @@ test('hook accepts correct header', (t) => {
   }
 
   const hook = plugin(keys)
+  hook(request, response, () => {
+    t.pass()
+  })
+})
+
+test('hook accepts correct header and alternate Bearer', (t) => {
+  t.plan(1)
+
+  const request = {
+    log: { error: noop },
+    req: {
+      headers: { authorization: `BearerAlt ${key}` }
+    }
+  }
+  const response = {
+    code: () => response,
+    send: send
+  }
+
+  function send (body) {
+    t.fail('should not happen')
+  }
+
+  const hook = plugin(keysAlt)
   hook(request, response, () => {
     t.pass()
   })

--- a/test/hook.test.js
+++ b/test/hook.test.js
@@ -5,8 +5,6 @@ const noop = () => {}
 const plugin = require('../').internals.factory
 const key = '123456789012354579814'
 const keys = { keys: new Set([key]) }
-const bearerAlt = 'BearerAlt'
-const keysAlt = { keys: new Set([key]), bearerType: bearerAlt }
 
 test('hook rejects for missing header', (t) => {
   t.plan(2)
@@ -102,6 +100,8 @@ test('hook accepts correct header', (t) => {
 test('hook accepts correct header and alternate Bearer', (t) => {
   t.plan(1)
 
+  const bearerAlt = 'BearerAlt'
+  const keysAlt = { keys: new Set([key]), bearerType: bearerAlt }
   const request = {
     log: { error: noop },
     req: {


### PR DESCRIPTION
Hi!,
sometimes the authentication string does not start with `Bearer`. I've updated the code to allow other types of API Keys. For example:
`Authorization: ApplePass <token_string>`

Thanks for the good work!.