### PR TITLE
Use `crypto.timingSafeEqual()` instead of `secure-compare` module

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "tsd": "^0.11.0"
   },
   "dependencies": {
-    "fastify-plugin": "^2.0.0",
-    "secure-compare": "^3.0.1"
+    "fastify-plugin": "^2.0.0"
   },
   "tsd": {
     "directory": "test",

--- a/plugin.js
+++ b/plugin.js
@@ -1,7 +1,7 @@
 'use strict'
 
+const crypto = require('crypto')
 const fp = require('fastify-plugin')
-const compare = require('secure-compare')
 
 function factory (options) {
   const defaultOptions = {
@@ -78,6 +78,13 @@ function factory (options) {
 
 function authenticate (keys, key) {
   return keys.findIndex((a) => compare(a, key)) !== -1
+}
+
+function compare (a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string') return false
+  if (a.length !== b.length) return false
+  // constant-time comparison to prevent timing attacks
+  return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b))
 }
 
 function plugin (fastify, options, next) {

--- a/plugin.js
+++ b/plugin.js
@@ -80,11 +80,14 @@ function authenticate (keys, key) {
   return keys.findIndex((a) => compare(a, key)) !== -1
 }
 
+// perform constant-time comparison to prevent timing attacks
 function compare (a, b) {
-  if (typeof a !== 'string' || typeof b !== 'string') return false
-  if (a.length !== b.length) return false
-  // constant-time comparison to prevent timing attacks
-  return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b))
+  try {
+    // may throw if they have different length, can't convert to Buffer, etc...
+    return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b))
+  } catch {
+    return false
+  }
 }
 
 function plugin (fastify, options, next) {


### PR DESCRIPTION
Since [`secure-compare`](https://github.com/vadimdemedes/secure-compare) says 

> If you're targeting Node.js v6.6.0+, use crypto.timingSafeEqual instead.

I fixed it and removed its dependency.

Is this reasonable?