### PR TITLE
Use request.raw (request.req is deprecated) for fastify@3

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -18,7 +18,7 @@ function factory (options) {
   const { keys, errorResponse, contentType, bearerType, auth } = _options
 
   function bearerAuthHook (fastifyReq, fastifyRes, next) {
-    const header = fastifyReq.req.headers.authorization
+    const header = fastifyReq.raw.headers.authorization
     if (!header) {
       const noHeaderError = Error('missing authorization header')
       fastifyReq.log.error('unauthorized: %s', noHeaderError.message)

--- a/test/hook.test.js
+++ b/test/hook.test.js
@@ -11,7 +11,7 @@ test('hook rejects for missing header', (t) => {
 
   const request = {
     log: { error: noop },
-    req: { headers: {} }
+    raw: { headers: {} }
   }
   const response = {
     code: () => response,
@@ -32,7 +32,7 @@ test('hook rejects header without bearer prefix', (t) => {
 
   const request = {
     log: { error: noop },
-    req: {
+    raw: {
       headers: { authorization: key }
     }
   }
@@ -55,7 +55,7 @@ test('hook rejects malformed header', (t) => {
 
   const request = {
     log: { error: noop },
-    req: {
+    raw: {
       headers: { authorization: `bearerr ${key}` }
     }
   }
@@ -78,7 +78,7 @@ test('hook accepts correct header', (t) => {
 
   const request = {
     log: { error: noop },
-    req: {
+    raw: {
       headers: { authorization: `bearer ${key}` }
     }
   }
@@ -104,7 +104,7 @@ test('hook accepts correct header and alternate Bearer', (t) => {
   const keysAlt = { keys: new Set([key]), bearerType: bearerAlt }
   const request = {
     log: { error: noop },
-    req: {
+    raw: {
       headers: { authorization: `BearerAlt ${key}` }
     }
   }
@@ -128,7 +128,7 @@ test('hook accepts correct header with extra padding', (t) => {
 
   const request = {
     log: { error: noop },
-    req: {
+    raw: {
       headers: { authorization: `bearer   ${key}   ` }
     }
   }
@@ -155,7 +155,7 @@ test('hook accepts correct header with auth function (promise)', (t) => {
   }
   const request = {
     log: { error: noop },
-    req: {
+    raw: {
       headers: { authorization: `bearer ${key}` }
     }
   }
@@ -182,7 +182,7 @@ test('hook accepts correct header with auth function (non-promise)', (t) => {
   }
   const request = {
     log: { error: noop },
-    req: {
+    raw: {
       headers: { authorization: `bearer ${key}` }
     }
   }
@@ -206,7 +206,7 @@ test('hook rejects wrong token with keys', (t) => {
 
   const request = {
     log: { error: noop },
-    req: {
+    raw: {
       headers: { authorization: 'bearer abcdedfg' }
     }
   }
@@ -231,7 +231,7 @@ test('hook rejects wrong token with auth function', (t) => {
 
   const request = {
     log: { error: noop },
-    req: {
+    raw: {
       headers: { authorization: 'bearer abcdefg' }
     }
   }
@@ -271,7 +271,7 @@ test('hook rejects wrong token with function (resolved promise)', (t) => {
 
   const request = {
     log: { error: noop },
-    req: {
+    raw: {
       headers: { authorization: 'bearer abcdefg' }
     }
   }
@@ -304,7 +304,7 @@ test('hook rejects with 500 when functions fails', (t) => {
 
   const request = {
     log: { error: noop },
-    req: {
+    raw: {
       headers: { authorization: 'bearer abcdefg' }
     }
   }
@@ -337,7 +337,7 @@ test('hook rejects with 500 when promise rejects', (t) => {
 
   const request = {
     log: { error: noop },
-    req: {
+    raw: {
       headers: { authorization: 'bearer abcdefg' }
     }
   }
@@ -370,7 +370,7 @@ test('hook rejects with 500 when functions returns non-boolean', (t) => {
 
   const request = {
     log: { error: noop },
-    req: {
+    raw: {
       headers: { authorization: 'bearer abcdefg' }
     }
   }
@@ -403,7 +403,7 @@ test('hook rejects with 500 when promise resolves to non-boolean', (t) => {
 
   const request = {
     log: { error: noop },
-    req: {
+    raw: {
       headers: { authorization: 'bearer abcdefg' }
     }
   }


### PR DESCRIPTION
> (node:71997) [FSTDEP001] FastifyDeprecation [FSTDEP001]: You are accessing the Node.js core request object via "request.req", Use "request.raw" instead.

I've noticed this warnings when running tests. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] ~documentation is changed or added~
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
