### PR TITLE
fix: add promise return type to auth function

### DIFF
--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -3,7 +3,7 @@ import * as fastify from 'fastify'
 declare namespace fastifyBearerAuth {
 	export interface FastifyBearerAuthOptions {
 		keys: Set<string>,
-		auth?: (key: string, req: fastify.FastifyRequest) => boolean,
+		auth?: (key: string, req: fastify.FastifyRequest) => boolean | Promise<boolean>,
 		errorResponse?: (err: Error) => { error: string },
 		contentType?: string,
 		bearerType?: string

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -10,12 +10,29 @@ const pluginOptions: FastifyBearerAuthOptions = {
 	bearerType: ''
 }
 
+const pluginOptionsAuthPromise: FastifyBearerAuthOptions = {
+	keys: new Set(['foo']),
+	auth: (key: string, req: FastifyRequest) => { return Promise.resolve(true) },
+	errorResponse: (err: Error) => { return { error: err.message } },
+	contentType: '',
+	bearerType: ''
+}
+
 expectAssignable<{
 	keys: Set<string>,
-	auth?: (key: string, req: FastifyRequest) => boolean,
+	auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>,
 	errorResponse?: (err: Error) => { error: string },
 	contentType?: string,
 	bearerType?: string
 }>(pluginOptions)
 
+expectAssignable<{
+	keys: Set<string>,
+	auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>,
+	errorResponse?: (err: Error) => { error: string },
+	contentType?: string,
+	bearerType?: string
+}>(pluginOptionsAuthPromise)
+
 fastify().register(bearerAuth, pluginOptions)
+fastify().register(bearerAuth, pluginOptionsAuthPromise)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Add missing `Promise<boolean>` type for the `auth` configuration property. 

The documentation says:

> The function must return a literal true if the key is accepted or a literal false if rejected. The function may return also a promise that resolves to one of these values.

However, the type only allowed for a `boolean` literal.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
