### PR TITLE
feat: add verify decorator to fastify

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,7 +56,9 @@ sent to the client (optional)
    rejects, or throws, a HTTP status of `500` will be sent. `req` is the Fastify
    request object. If `auth` is a function, `keys` will be ignored. If `auth` is
    not a function, or `undefined`, `keys` will be used.
-* `addHook`: If `false`, this plugin will not register `onRequest` hook automatically.
+* `addHook`: If `false`, this plugin will not register `onRequest` hook automatically,
+   instead it provide two decorations `fastify.verifyBearerAuth` and
+   `fastify.verifyBearerAuthFactory` for you.
 
 The default configuration object is:
 

--- a/Readme.md
+++ b/Readme.md
@@ -87,7 +87,7 @@ a `{error: message}` body; no further request processing will be performed.
 
 This plugin can integrate with `fastify-auth` by following this example:
 
-```JS
+```js
 const fastify = require('fastify')()
 const bearerAuthPlugin = require('fastify-bearer-auth')
 const keys = new Set(['a-super-secret-key', 'another-super-secret-key'])

--- a/Readme.md
+++ b/Readme.md
@@ -85,7 +85,7 @@ a `{error: message}` body; no further request processing will be performed.
 
 ## Integration with `fastify-auth`
 
-This plugin can integrate with `fastify-auth`, you can follow the example below.
+This plugin can integrate with `fastify-auth` by following this example:
 
 ```JS
 const fastify = require('fastify')()

--- a/Readme.md
+++ b/Readme.md
@@ -56,7 +56,7 @@ sent to the client (optional)
    rejects, or throws, a HTTP status of `500` will be sent. `req` is the Fastify
    request object. If `auth` is a function, `keys` will be ignored. If `auth` is
    not a function, or `undefined`, `keys` will be used.
-* `legacy`: turn on legacy mode to add bearer auth for `onRequest` hook.
+* `addHook`: If `false`, this plugin will not register `onRequest` hook automatically.
 
 The default configuration object is:
 
@@ -69,7 +69,7 @@ The default configuration object is:
       return {error: err.message}
     },
     auth: undefined,
-    legacy: undefined
+    addHook: true
 }
 ```
 
@@ -88,6 +88,12 @@ a `{error: message}` body; no further request processing will be performed.
 This plugin can integrate with `fastify-auth`, you can follow the example below.
 
 ```JS
+const fastify = require('fastify')()
+const bearerAuthPlugin = require('fastify-bearer-auth')
+const keys = new Set(['a-super-secret-key', 'another-super-secret-key'])
+
+fastify.register(bearerAuthPlugin, { addHook: false, keys})
+
 fastify.route({
   method: 'GET',
   url: '/multiauth',

--- a/Readme.md
+++ b/Readme.md
@@ -83,7 +83,7 @@ a `{error: message}` body; no further request processing will be performed.
 [fplugin]: https://github.com/fastify/fastify/blob/master/docs/Plugins.md
 [prehook]: https://github.com/fastify/fastify/blob/master/docs/Hooks.md
 
-## Integration
+## Integration with `fastify-auth`
 
 This plugin can integrate with `fastify-auth`, you can follow the example below.
 

--- a/Readme.md
+++ b/Readme.md
@@ -56,6 +56,7 @@ sent to the client (optional)
    rejects, or throws, a HTTP status of `500` will be sent. `req` is the Fastify
    request object. If `auth` is a function, `keys` will be ignored. If `auth` is
    not a function, or `undefined`, `keys` will be used.
+* `legacy`: turn on legacy mode to add bearer auth for `onRequest` hook.
 
 The default configuration object is:
 
@@ -67,7 +68,8 @@ The default configuration object is:
     errorResponse: (err) => {
       return {error: err.message}
     },
-    auth: undefined
+    auth: undefined,
+    legacy: undefined
 }
 ```
 
@@ -80,6 +82,24 @@ a `{error: message}` body; no further request processing will be performed.
 
 [fplugin]: https://github.com/fastify/fastify/blob/master/docs/Plugins.md
 [prehook]: https://github.com/fastify/fastify/blob/master/docs/Hooks.md
+
+## Integration
+
+This plugin can integrate with `fastify-auth`, you can follow the example below.
+
+```JS
+fastify.route({
+  method: 'GET',
+  url: '/multiauth',
+  preHandler: fastify.auth([
+    fastify.allowAnonymous,
+    fastify.verifyBearerAuth
+  ]),
+  handler: function (_, reply) {
+    reply.send({ hello: 'world' })
+  }
+})
+```
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@types/node": "^14.0.18",
     "fastify": "^3.0.0",
+    "fastify-auth": "^1.0.1",
     "pre-commit": "^1.2.2",
     "snazzy": "^9.0.0",
     "standard": "^16.0.1",

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1,14 +1,14 @@
 import * as fastify from 'fastify'
 
 declare namespace fastifyBearerAuth {
-	export interface FastifyBearerAuthOptions {
-		keys: Set<string>,
-		auth?: (key: string, req: fastify.FastifyRequest) => boolean | Promise<boolean>,
-		errorResponse?: (err: Error) => { error: string },
-		contentType?: string,
-		bearerType?: string,
+  export interface FastifyBearerAuthOptions {
+    keys: Set<string>,
+    auth?: (key: string, req: fastify.FastifyRequest) => boolean | Promise<boolean>,
+    errorResponse?: (err: Error) => { error: string },
+    contentType?: string,
+    bearerType?: string,
     addHook?: boolean
-	}
+  }
 }
 
 declare const fastifyBearerAuth: fastify.FastifyPlugin<fastifyBearerAuth.FastifyBearerAuthOptions>

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -9,6 +9,16 @@ declare namespace fastifyBearerAuth {
     bearerType?: string,
     addHook?: boolean
   }
+
+  export type verifyBearerAuth = (request: fastify.FastifyRequest, reply: fastify.FastifyReply, done: (err?: Error) => void) => void
+  export type verifyBearerAuthFactory = (options: fastifyBearerAuth.FastifyBearerAuthOptions) => verifyBearerAuth
+}
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    verifyBearerAuthFactory?: fastifyBearerAuth.verifyBearerAuthFactory
+    verifyBearerAuth?: fastifyBearerAuth.verifyBearerAuth
+  }
 }
 
 declare const fastifyBearerAuth: fastify.FastifyPlugin<fastifyBearerAuth.FastifyBearerAuthOptions>

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -6,7 +6,8 @@ declare namespace fastifyBearerAuth {
 		auth?: (key: string, req: fastify.FastifyRequest) => boolean | Promise<boolean>,
 		errorResponse?: (err: Error) => { error: string },
 		contentType?: string,
-		bearerType?: string
+		bearerType?: string,
+    addHook?: boolean
 	}
 }
 

--- a/plugin.js
+++ b/plugin.js
@@ -95,7 +95,7 @@ function plugin (fastify, options, done) {
   fastify.decorate('verifyBearerAuthFactory', verifyBearerAuthFactory)
   fastify.decorate('verifyBearerAuth', verifyBearerAuthFactory(options))
 
-  if (options.addHook) {
+  if (options.addHook === true) {
     fastify.addHook('onRequest', verifyBearerAuthFactory(options))
   }
 

--- a/plugin.js
+++ b/plugin.js
@@ -90,10 +90,12 @@ function compare (a, b) {
 }
 
 function plugin (fastify, options, done) {
+  options = Object.assign({ addHook: true }, options)
+
   fastify.decorate('verifyBearerAuthFactory', verifyBearerAuthFactory)
   fastify.decorate('verifyBearerAuth', verifyBearerAuthFactory(options))
 
-  if (options.legacy) {
+  if (options.addHook) {
     fastify.addHook('onRequest', verifyBearerAuthFactory(options))
   }
 

--- a/plugin.js
+++ b/plugin.js
@@ -92,11 +92,11 @@ function compare (a, b) {
 function plugin (fastify, options, done) {
   options = Object.assign({ addHook: true }, options)
 
-  fastify.decorate('verifyBearerAuthFactory', verifyBearerAuthFactory)
-  fastify.decorate('verifyBearerAuth', verifyBearerAuthFactory(options))
-
   if (options.addHook === true) {
     fastify.addHook('onRequest', verifyBearerAuthFactory(options))
+  } else {
+    fastify.decorate('verifyBearerAuthFactory', verifyBearerAuthFactory)
+    fastify.decorate('verifyBearerAuth', verifyBearerAuthFactory(options))
   }
 
   done()

--- a/plugin.js
+++ b/plugin.js
@@ -3,27 +3,28 @@
 const crypto = require('crypto')
 const fp = require('fastify-plugin')
 
-function factory (options) {
-  const defaultOptions = {
-    keys: [],
-    auth: undefined,
-    errorResponse (err) {
-      return { error: err.message }
-    },
-    contentType: undefined,
-    bearerType: 'Bearer'
-  }
-  const _options = { ...defaultOptions, ...options || {} }
+const defaultOptions = {
+  keys: [],
+  auth: undefined,
+  errorResponse (err) {
+    return { error: err.message }
+  },
+  contentType: undefined,
+  bearerType: 'Bearer'
+}
+
+function verifyBearerAuthFactory (options) {
+  const _options = Object.assign({}, defaultOptions, options)
   if (_options.keys instanceof Set) _options.keys = Array.from(_options.keys)
   const { keys, errorResponse, contentType, bearerType, auth } = _options
 
-  function bearerAuthHook (fastifyReq, fastifyRes, next) {
-    const header = fastifyReq.raw.headers.authorization
+  return function verifyBearerAuth (request, reply, done) {
+    const header = request.raw.headers.authorization
     if (!header) {
       const noHeaderError = Error('missing authorization header')
-      fastifyReq.log.error('unauthorized: %s', noHeaderError.message)
-      if (contentType) fastifyRes.header('content-type', contentType)
-      fastifyRes.code(401).send(errorResponse(noHeaderError))
+      request.log.error('unauthorized: %s', noHeaderError.message)
+      if (contentType) reply.header('content-type', contentType)
+      reply.code(401).send(errorResponse(noHeaderError))
       return
     }
 
@@ -32,7 +33,7 @@ function factory (options) {
     // check if auth function is defined
     if (auth && auth instanceof Function) {
       try {
-        retVal = auth(key, fastifyReq)
+        retVal = auth(key, request)
       // catch any error from the user provided function
       } catch (err) {
         retVal = Promise.reject(err)
@@ -53,27 +54,25 @@ function factory (options) {
     Promise.resolve(retVal).then((val) => {
       // if val is not truthy return 401
       if (val === false) {
-        fastifyReq.log.error('invalid authorization header: `%s`', header)
-        if (contentType) fastifyRes.header('content-type', contentType)
-        fastifyRes.code(401).send(errorResponse(invalidKeyError))
+        request.log.error('invalid authorization header: `%s`', header)
+        if (contentType) reply.header('content-type', contentType)
+        reply.code(401).send(errorResponse(invalidKeyError))
         return
       }
       if (val === true) {
         // if it fails down stream return the proper error
         try {
-          next()
+          done()
         } catch (err) {
-          next(err)
+          done(err)
         }
         return
       }
-      fastifyRes.code(500).send(errorResponse(new Error('internal server error')))
+      reply.code(500).send(errorResponse(new Error('internal server error')))
     }).catch((err) => {
-      fastifyRes.code(500).send(errorResponse(err instanceof Error ? err : Error(String(err))))
+      reply.code(500).send(errorResponse(err instanceof Error ? err : Error(String(err))))
     })
   }
-
-  return bearerAuthHook
 }
 
 function authenticate (keys, key) {
@@ -90,13 +89,19 @@ function compare (a, b) {
   }
 }
 
-function plugin (fastify, options, next) {
-  fastify.addHook('onRequest', factory(options))
-  next()
+function plugin (fastify, options, done) {
+  fastify.decorate('verifyBearerAuthFactory', verifyBearerAuthFactory)
+  fastify.decorate('verifyBearerAuth', verifyBearerAuthFactory(options))
+
+  if (options.legacy) {
+    fastify.addHook('onRequest', verifyBearerAuthFactory(options))
+  }
+
+  done()
 }
 
 module.exports = fp(plugin, {
   fastify: '3.x',
   name: 'fastify-bearer-auth'
 })
-module.exports.internals = { factory }
+module.exports.internals = { factory: verifyBearerAuthFactory }

--- a/test/decorate.test.js
+++ b/test/decorate.test.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const tap = require('tap')
+const test = tap.test
+const fastify = require('fastify')()
+const plugin = require('../')
+
+fastify.register(plugin, { legacy: true, keys: new Set(['123456']) })
+
+test('verifyBearerAuth', (t) => {
+  t.plan(1)
+  fastify.ready(() => {
+    t.ok(fastify.verifyBearerAuth)
+  })
+})
+
+test('verifyBearerAuthFactory', (t) => {
+  t.plan(1)
+  fastify.ready(() => {
+    t.ok(fastify.verifyBearerAuthFactory)
+  })
+})

--- a/test/decorate.test.js
+++ b/test/decorate.test.js
@@ -5,7 +5,7 @@ const test = tap.test
 const fastify = require('fastify')()
 const plugin = require('../')
 
-fastify.register(plugin, { legacy: true, keys: new Set(['123456']) })
+fastify.register(plugin, { addHook: false, keys: new Set(['123456']) })
 
 test('verifyBearerAuth', (t) => {
   t.plan(1)

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -5,7 +5,7 @@ const test = tap.test
 const fastify = require('fastify')()
 const plugin = require('../')
 
-fastify.register(plugin, { legacy: true, keys: new Set(['123456']) })
+fastify.register(plugin, { keys: new Set(['123456']) })
 
 fastify.get('/test', (req, res) => {
   res.send({ hello: 'world' })
@@ -54,8 +54,10 @@ test('missing header route fails correctly', (t) => {
 })
 
 test('integration with fastify-auth', async (t) => {
+  t.plan(3)
+
   const fastify = require('fastify')()
-  await fastify.register(plugin, { keys: new Set(['123456']) })
+  await fastify.register(plugin, { addHook: false, keys: new Set(['123456']) })
   await fastify.decorate('allowAnonymous', function (request, _, done) {
     if (!request.headers.authorization) {
       return done()
@@ -78,7 +80,7 @@ test('integration with fastify-auth', async (t) => {
 
   await fastify.ready()
 
-  test('anonymous should pass', async (t) => {
+  t.test('anonymous should pass', async (t) => {
     t.plan(2)
     try {
       const res = await fastify.inject({ method: 'GET', url: '/anonymous' })
@@ -89,7 +91,7 @@ test('integration with fastify-auth', async (t) => {
     }
   })
 
-  test('bearer auth should pass', async (t) => {
+  t.test('bearer auth should pass', async (t) => {
     t.plan(2)
     try {
       const res = await fastify.inject({
@@ -106,7 +108,7 @@ test('integration with fastify-auth', async (t) => {
     }
   })
 
-  test('bearer auth should fail', async (t) => {
+  t.test('bearer auth should fail', async (t) => {
     t.plan(2)
     try {
       const res = await fastify.inject({

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -3,36 +3,36 @@ import { expectAssignable } from 'tsd'
 import bearerAuth, { FastifyBearerAuthOptions } from '../plugin'
 
 const pluginOptions: FastifyBearerAuthOptions = {
-	keys: new Set(['foo']),
-	auth: (key: string, req: FastifyRequest) => { return true },
-	errorResponse: (err: Error) => { return { error: err.message } },
-	contentType: '',
-	bearerType: '',
+  keys: new Set(['foo']),
+  auth: (key: string, req: FastifyRequest) => { return true },
+  errorResponse: (err: Error) => { return { error: err.message } },
+  contentType: '',
+  bearerType: '',
   addHook: false
 }
 
 const pluginOptionsAuthPromise: FastifyBearerAuthOptions = {
-	keys: new Set(['foo']),
-	auth: (key: string, req: FastifyRequest) => { return Promise.resolve(true) },
-	errorResponse: (err: Error) => { return { error: err.message } },
-	contentType: '',
-	bearerType: ''
+  keys: new Set(['foo']),
+  auth: (key: string, req: FastifyRequest) => { return Promise.resolve(true) },
+  errorResponse: (err: Error) => { return { error: err.message } },
+  contentType: '',
+  bearerType: ''
 }
 
 expectAssignable<{
-	keys: Set<string>,
-	auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>,
-	errorResponse?: (err: Error) => { error: string },
-	contentType?: string,
-	bearerType?: string
+  keys: Set<string>,
+  auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>,
+  errorResponse?: (err: Error) => { error: string },
+  contentType?: string,
+  bearerType?: string
 }>(pluginOptions)
 
 expectAssignable<{
-	keys: Set<string>,
-	auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>,
-	errorResponse?: (err: Error) => { error: string },
-	contentType?: string,
-	bearerType?: string
+  keys: Set<string>,
+  auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>,
+  errorResponse?: (err: Error) => { error: string },
+  contentType?: string,
+  bearerType?: string
 }>(pluginOptionsAuthPromise)
 
 fastify().register(bearerAuth, pluginOptions)

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -1,6 +1,6 @@
 import fastify, { FastifyRequest } from 'fastify'
-import { expectAssignable } from 'tsd'
-import bearerAuth, { FastifyBearerAuthOptions } from '../plugin'
+import { expectAssignable, expectType } from 'tsd'
+import { default as bearerAuth, FastifyBearerAuthOptions } from '../plugin'
 
 const pluginOptions: FastifyBearerAuthOptions = {
   keys: new Set(['foo']),
@@ -37,3 +37,6 @@ expectAssignable<{
 
 fastify().register(bearerAuth, pluginOptions)
 fastify().register(bearerAuth, pluginOptionsAuthPromise)
+
+expectType<bearerAuth.verifyBearerAuth | undefined>(fastify().verifyBearerAuth)
+expectType<bearerAuth.verifyBearerAuthFactory | undefined>(fastify().verifyBearerAuthFactory)

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -1,13 +1,14 @@
 import fastify, { FastifyRequest } from 'fastify'
-import bearerAuth, { FastifyBearerAuthOptions } from '../plugin'
 import { expectAssignable } from 'tsd'
+import bearerAuth, { FastifyBearerAuthOptions } from '../plugin'
 
 const pluginOptions: FastifyBearerAuthOptions = {
 	keys: new Set(['foo']),
 	auth: (key: string, req: FastifyRequest) => { return true },
 	errorResponse: (err: Error) => { return { error: err.message } },
 	contentType: '',
-	bearerType: ''
+	bearerType: '',
+  addHook: false
 }
 
 const pluginOptionsAuthPromise: FastifyBearerAuthOptions = {


### PR DESCRIPTION
Fixes: #63 

Changes:
- add options `legacy` to add `onRequest` hooks as before
- add `verifyBearerAuth` to `fastify` to allow simple use-case
- add `verifyBearerAuthFactory` to `fastify` to allow complex use-case
- add example for simple integration

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
