### PR TITLE
ci: add `matrix.os` array to test on other os

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
         run: |
           npm install --ignore-scripts
 
+      - name: Lint
+        run: |
+          npm run lint:ci
+
       - name: Run Tests
         run: |
           npm run test:ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
-name: CI workflow
+name: CI
+
 on:
   push:
     paths-ignore:
@@ -8,25 +9,32 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
+
 jobs:
-  ci:
-    name: CI
-    runs-on: ubuntu-latest
+  test:
+    runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
-        node-version: [ '10', '12', '14' ]
+        node-version: [10.x, 12.x, 14.x]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
     steps:
       - uses: actions/checkout@v2
-      - name: Setup node
+
+      - name: Use Node.js
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: ${{ matrix.node }}
+          node-version: ${{ matrix.node-version }}
+
       - name: Install Dependencies
-        run: npm install --ignore-scripts
-      - name: Lint
-        run: npm run lint-ci
-      - name: Tests
-        run: npm run test-ci
+        run: |
+          npm install --ignore-scripts
+
+      - name: Run Tests
+        run: |
+          npm run test:ci
+
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@v1.1.2
         with:
@@ -35,7 +43,7 @@ jobs:
           flag-name: run-${{ matrix.node-version }}-${{ matrix.os }}
 
   coverage:
-    needs: ci
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
@@ -45,7 +53,7 @@ jobs:
           parallel-finished: true
 
   automerge:
-    needs: ci
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: fastify/github-action-merge-dependabot@v2.0.0

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 # fastify-bearer-auth
 
+![CI](https://github.com/fastify/fastify-bearer-auth/workflows/CI/badge.svg)
 [![npm version](https://img.shields.io/npm/v/fastify-bearer-auth)](https://www.npmjs.com/package/fastify-bearer-auth)
-![](https://github.com/fastify/fastify-bearer-auth/workflows/CI%20workflow/badge.svg)
 [![Known Vulnerabilities](https://snyk.io/test/github/fastify/fastify-bearer-auth/badge.svg)](https://snyk.io/test/github/fastify/fastify-bearer-auth)
 [![Coverage Status](https://coveralls.io/repos/github/fastify/fastify-bearer-auth/badge.svg?branch=master)](https://coveralls.io/github/fastify/fastify-bearer-auth?branch=master)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "types": "plugin.d.ts",
   "scripts": {
     "lint": "standard | snazzy",
-    "lint-ci": "standard",
+    "lint:ci": "standard",
     "test": "tap \"test/**/*.test.js\" && tsd",
-    "test-ci": "tap \"test/**/*.test.js\" --coverage-report=lcovonly && tsd"
+    "test:ci": "tap \"test/**/*.test.js\" --coverage-report=lcovonly && tsd"
   },
   "precommit": [
     "lint",


### PR DESCRIPTION
Adds MacOS and Windows OSes to CI testing
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
