### PR TITLE
fix: verifyBearerAuth to call done(error) on error

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -110,10 +110,9 @@ fastify.route({
 ```
 
 By passing `{ addHook: false }` in the options, the `verifyBearerAuth` hook, instead of
-immediately replying on error (`reply.send(someError)`), it calls `done(someError)`. This
-will allow `fastify.auth` to take back control and try to authenticate the request with the
-next hook in the list. If `verifyBearerAuth` is the last hook in the list, `fastify.auth`
-will reply with `Unauthorized`.
+immediately replying on error (`reply.send(someError)`), invokes `done(someError)`. This
+will allow `fastify.auth` to continue with the next authentication scheme in the hook list.
+If `verifyBearerAuth` is the last hook in the list, `fastify.auth` will reply with `Unauthorized`.
 ## License
 
 [MIT License](https://jsumners.mit-license.org/)

--- a/Readme.md
+++ b/Readme.md
@@ -109,6 +109,11 @@ fastify.route({
 })
 ```
 
+By passing `{ addHook: false }` in the options, the `verifyBearerAuth` hook, instead of
+immediately replying on error (`reply.send(someError)`), it calls `done(someError)`. This
+will allow `fastify.auth` to take back control and try to authenticate the request with the
+next hook in the list. If `verifyBearerAuth` is the last hook in the list, `fastify.auth`
+will reply with `Unauthorized`.
 ## License
 
 [MIT License](https://jsumners.mit-license.org/)

--- a/test/hook.test.js
+++ b/test/hook.test.js
@@ -547,3 +547,59 @@ test('hook rejects with 500 when promise resolves to non-boolean', (t) => {
     t.fail('should not accept')
   })
 })
+
+test('hook rejects with 500 when functions returns non-boolean (addHook: false)', (t) => {
+  t.plan(4)
+
+  const auth = function (val) {
+    t.equal(val, 'abcdefg', 'wrong argument')
+    return 'foobar'
+  }
+
+  const request = {
+    log: { error: noop },
+    raw: {
+      headers: { authorization: 'bearer abcdefg' }
+    }
+  }
+  const response = {
+    code: (status) => {
+      t.equal(500, status)
+      return response
+    }
+  }
+
+  const hook = plugin({ auth, addHook: false })
+  hook(request, response, (err) => {
+    t.ok(err)
+    t.match(err.message, /internal server error/)
+  })
+})
+
+test('hook rejects with 500 when promise rejects (addHook: false)', (t) => {
+  t.plan(4)
+
+  const auth = function (val) {
+    t.equal(val, 'abcdefg', 'wrong argument')
+    return Promise.reject(Error('failing'))
+  }
+
+  const request = {
+    log: { error: noop },
+    raw: {
+      headers: { authorization: 'bearer abcdefg' }
+    }
+  }
+  const response = {
+    code: (status) => {
+      t.equal(500, status)
+      return response
+    }
+  }
+
+  const hook = plugin({ auth, addHook: false })
+  hook(request, response, (err) => {
+    t.ok(err)
+    t.match(err.message, /failing/)
+  })
+})

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -108,7 +108,7 @@ test('integration with fastify-auth', async (t) => {
     }
   })
 
-  t.test('bearer auth should fail', async (t) => {
+  t.test('bearer auth should fail, so fastify.auth fails', async (t) => {
     t.plan(2)
     try {
       const res = await fastify.inject({
@@ -119,7 +119,81 @@ test('integration with fastify-auth', async (t) => {
         }
       })
       t.equal(res.statusCode, 401)
-      t.match(JSON.parse(res.body).error, /invalid authorization header/)
+      t.match(JSON.parse(res.body).error, /Unauthorized/)
+    } catch (err) {
+      t.error(err)
+    }
+  })
+})
+
+test('integration with fastify-auth; not the last auth option', async (t) => {
+  t.plan(3)
+
+  const fastify = require('fastify')()
+  await fastify.register(plugin, { addHook: false, keys: new Set(['123456']) })
+  await fastify.decorate('alwaysValidAuth', function (request, _, done) {
+    return done()
+  })
+  await fastify.register(require('fastify-auth'))
+
+  fastify.route({
+    method: 'GET',
+    url: '/bearer-first',
+    preHandler: fastify.auth([
+      fastify.verifyBearerAuth,
+      fastify.alwaysValidAuth
+    ]),
+    handler: function (_, reply) {
+      reply.send({ hello: 'world' })
+    }
+  })
+
+  await fastify.ready()
+
+  t.test('bearer auth should pass so fastify.auth should pass', async (t) => {
+    t.plan(2)
+    try {
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/bearer-first',
+        headers: {
+          authorization: 'Bearer 123456'
+        }
+      })
+      t.equal(res.statusCode, 200)
+      t.match(JSON.parse(res.body).hello, 'world')
+    } catch (err) {
+      t.error(err)
+    }
+  })
+
+  t.test('bearer should fail but fastify.auth should pass', async (t) => {
+    t.plan(2)
+    try {
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/bearer-first',
+        headers: {
+          authorization: 'Bearer fail'
+        }
+      })
+      t.equal(res.statusCode, 200)
+      t.match(JSON.parse(res.body).hello, 'world')
+    } catch (err) {
+      t.error(err)
+    }
+  })
+
+  t.test('bearer should fail but fastify.auth should pass', async (t) => {
+    t.plan(2)
+    try {
+      const res = await fastify.inject({
+        method: 'GET',
+        url: '/bearer-first',
+        headers: {}
+      })
+      t.equal(res.statusCode, 200)
+      t.match(JSON.parse(res.body).hello, 'world')
     } catch (err) {
       t.error(err)
     }

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -82,47 +82,35 @@ test('integration with fastify-auth', async (t) => {
 
   t.test('anonymous should pass', async (t) => {
     t.plan(2)
-    try {
-      const res = await fastify.inject({ method: 'GET', url: '/anonymous' })
-      t.equal(res.statusCode, 200)
-      t.match(JSON.parse(res.body).hello, 'world')
-    } catch (err) {
-      t.error(err)
-    }
+    const res = await fastify.inject({ method: 'GET', url: '/anonymous' })
+    t.equal(res.statusCode, 200)
+    t.match(JSON.parse(res.body).hello, 'world')
   })
 
   t.test('bearer auth should pass', async (t) => {
     t.plan(2)
-    try {
-      const res = await fastify.inject({
-        method: 'GET',
-        url: '/anonymous',
-        headers: {
-          authorization: 'Bearer 123456'
-        }
-      })
-      t.equal(res.statusCode, 200)
-      t.match(JSON.parse(res.body).hello, 'world')
-    } catch (err) {
-      t.error(err)
-    }
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/anonymous',
+      headers: {
+        authorization: 'Bearer 123456'
+      }
+    })
+    t.equal(res.statusCode, 200)
+    t.match(JSON.parse(res.body).hello, 'world')
   })
 
   t.test('bearer auth should fail, so fastify.auth fails', async (t) => {
     t.plan(2)
-    try {
-      const res = await fastify.inject({
-        method: 'GET',
-        url: '/anonymous',
-        headers: {
-          authorization: 'Bearer fail'
-        }
-      })
-      t.equal(res.statusCode, 401)
-      t.match(JSON.parse(res.body).error, /Unauthorized/)
-    } catch (err) {
-      t.error(err)
-    }
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/anonymous',
+      headers: {
+        authorization: 'Bearer fail'
+      }
+    })
+    t.equal(res.statusCode, 401)
+    t.match(JSON.parse(res.body).error, /Unauthorized/)
   })
 })
 
@@ -152,50 +140,38 @@ test('integration with fastify-auth; not the last auth option', async (t) => {
 
   t.test('bearer auth should pass so fastify.auth should pass', async (t) => {
     t.plan(2)
-    try {
-      const res = await fastify.inject({
-        method: 'GET',
-        url: '/bearer-first',
-        headers: {
-          authorization: 'Bearer 123456'
-        }
-      })
-      t.equal(res.statusCode, 200)
-      t.match(JSON.parse(res.body).hello, 'world')
-    } catch (err) {
-      t.error(err)
-    }
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/bearer-first',
+      headers: {
+        authorization: 'Bearer 123456'
+      }
+    })
+    t.equal(res.statusCode, 200)
+    t.match(JSON.parse(res.body).hello, 'world')
   })
 
   t.test('bearer should fail but fastify.auth should pass', async (t) => {
     t.plan(2)
-    try {
-      const res = await fastify.inject({
-        method: 'GET',
-        url: '/bearer-first',
-        headers: {
-          authorization: 'Bearer fail'
-        }
-      })
-      t.equal(res.statusCode, 200)
-      t.match(JSON.parse(res.body).hello, 'world')
-    } catch (err) {
-      t.error(err)
-    }
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/bearer-first',
+      headers: {
+        authorization: 'Bearer fail'
+      }
+    })
+    t.equal(res.statusCode, 200)
+    t.match(JSON.parse(res.body).hello, 'world')
   })
 
   t.test('bearer should fail but fastify.auth should pass', async (t) => {
     t.plan(2)
-    try {
-      const res = await fastify.inject({
-        method: 'GET',
-        url: '/bearer-first',
-        headers: {}
-      })
-      t.equal(res.statusCode, 200)
-      t.match(JSON.parse(res.body).hello, 'world')
-    } catch (err) {
-      t.error(err)
-    }
+    const res = await fastify.inject({
+      method: 'GET',
+      url: '/bearer-first',
+      headers: {}
+    })
+    t.equal(res.statusCode, 200)
+    t.match(JSON.parse(res.body).hello, 'world')
   })
 })


### PR DESCRIPTION
instead of replying to client

close #90

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ x ] run `npm run test` and `npm run benchmark`
- [ x ] tests and/or benchmarks are included
- [ x ] documentation is changed or added
- [ x ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
