### PR TITLE
docs(readme): update `fastify-auth` example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -95,7 +95,7 @@ const auth = require('fastify-auth')
 const bearerAuthPlugin = require('fastify-bearer-auth')
 const keys = new Set(['a-super-secret-key', 'another-super-secret-key'])
 
-const server = async function () {
+async function server() {
 
   await fastify
     .register(auth)
@@ -119,13 +119,7 @@ const server = async function () {
     }
   })
 
-  fastify.listen({port: 8000}, (err) => {
-    if (err) {
-      fastify.log.error(err.message)
-      process.exit(1)
-    }
-    fastify.log.info('http://127.0.0.1:8000/foo')
-  })
+  await fastify.listen({port: 8000})
 }
 
 server()


### PR DESCRIPTION
closes #80 by resolving the following issues with the original example:

- `fastify-auth` plugin not registered
- `allowAnonymous` decorator not added
- `fastify-auth` and `fastify-bearer-auth` plugins not waited on, leading to `UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'bind' of undefined`  being thrown

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
