### PR TITLE
Fix log error when addHook = false

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,7 +59,7 @@ sent to the client (optional)
 * `addHook`: If `false`, this plugin will not register `onRequest` hook automatically,
    instead it provide two decorations `fastify.verifyBearerAuth` and
    `fastify.verifyBearerAuthFactory` for you.
-* `verifyErrorLogLevel`: an optional string specifying the log level when there is a verification error.
+* `verifyErrorLogLevel`: An optional string specifying the log level when there is a verification error.
    It must be a valid log level supported by fastify, otherwise an exception will be thrown
    when registering the plugin. By default, this option is set to `error`.
 

--- a/Readme.md
+++ b/Readme.md
@@ -131,8 +131,7 @@ server()
 By passing `{ addHook: false }` in the options, the `verifyBearerAuth` hook, instead of
 immediately replying on error (`reply.send(someError)`), invokes `done(someError)`. This
 will allow `fastify.auth` to continue with the next authentication scheme in the hook list.
-Note that by setting `{ verifyErrorLogLevel: 'debug' }` in the options, `fastify-bearer-auth` will emit all the 
-verification's errors logs at the `debug` level. Since it is not the only authentication method here, to emit verification's errors logs at  the `error` level may be not appropriate here.
+Note that by setting `{ verifyErrorLogLevel: 'debug' }` in the options, `fastify-bearer-auth` will emit all verification error logs at the `debug` level. Since it is not the only authentication method here, emitting verification error logs at the `error` level may be not appropriate here.
 If `verifyBearerAuth` is the last hook in the list, `fastify.auth` will reply with `Unauthorized`.
 ## License
 

--- a/Readme.md
+++ b/Readme.md
@@ -59,6 +59,9 @@ sent to the client (optional)
 * `addHook`: If `false`, this plugin will not register `onRequest` hook automatically,
    instead it provide two decorations `fastify.verifyBearerAuth` and
    `fastify.verifyBearerAuthFactory` for you.
+* `verifyErrorLogLevel`: string specifying the log level when verify error (optional).
+   The value must be vaild log level support by fastify, otherwise exception will be throwed
+   when register the plugin. default value is `error`.
 
 The default configuration object is:
 
@@ -99,7 +102,7 @@ async function server() {
 
   await fastify
     .register(auth)
-    .register(bearerAuthPlugin, { addHook: false, keys})
+    .register(bearerAuthPlugin, { addHook: false, keys, verifyErrorLogLevel: 'debug' })
     .decorate('allowAnonymous', function (req, reply, done) {
       if (req.headers.authorization) {
         return done(Error('not anonymous'))
@@ -128,6 +131,9 @@ server()
 By passing `{ addHook: false }` in the options, the `verifyBearerAuth` hook, instead of
 immediately replying on error (`reply.send(someError)`), invokes `done(someError)`. This
 will allow `fastify.auth` to continue with the next authentication scheme in the hook list.
+Also by set `{ verifyErrorLogLevel: 'debug' }` in the options, the `fastify.auth` will log the 
+verify error to `debug` level, since it is not the only authentication method here, log at `error`
+level may be not appropiated.
 If `verifyBearerAuth` is the last hook in the list, `fastify.auth` will reply with `Unauthorized`.
 ## License
 

--- a/Readme.md
+++ b/Readme.md
@@ -131,9 +131,8 @@ server()
 By passing `{ addHook: false }` in the options, the `verifyBearerAuth` hook, instead of
 immediately replying on error (`reply.send(someError)`), invokes `done(someError)`. This
 will allow `fastify.auth` to continue with the next authentication scheme in the hook list.
-Also by set `{ verifyErrorLogLevel: 'debug' }` in the options, the `fastify.auth` will log the 
-verify error to `debug` level, since it is not the only authentication method here, log at `error`
-level may be not appropiated.
+Note that by setting `{ verifyErrorLogLevel: 'debug' }` in the options, `fastify-bearer-auth` will emit all the 
+verification's errors logs at the `debug` level. Since it is not the only authentication method here, to emit verification's errors logs at  the `error` level may be not appropriate here.
 If `verifyBearerAuth` is the last hook in the list, `fastify.auth` will reply with `Unauthorized`.
 ## License
 

--- a/Readme.md
+++ b/Readme.md
@@ -59,9 +59,9 @@ sent to the client (optional)
 * `addHook`: If `false`, this plugin will not register `onRequest` hook automatically,
    instead it provide two decorations `fastify.verifyBearerAuth` and
    `fastify.verifyBearerAuthFactory` for you.
-* `verifyErrorLogLevel`: string specifying the log level when verify error (optional).
-   The value must be vaild log level support by fastify, otherwise exception will be throwed
-   when register the plugin. default value is `error`.
+* `verifyErrorLogLevel`: an optional string specifying the log level when there is a verification error.
+   It must be a valid log level supported by fastify, otherwise an exception will be thrown
+   when registering the plugin. By default, this option is set to `error`.
 
 The default configuration object is:
 

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -7,7 +7,8 @@ declare namespace fastifyBearerAuth {
     errorResponse?: (err: Error) => { error: string },
     contentType?: string,
     bearerType?: string,
-    addHook?: boolean
+    addHook?: boolean,
+    verifyErrorLogLevel?: string
   }
 
   export type verifyBearerAuth = (request: fastify.FastifyRequest, reply: fastify.FastifyReply, done: (err?: Error) => void) => void

--- a/plugin.js
+++ b/plugin.js
@@ -17,9 +17,8 @@ function verifyBearerAuthFactory (options) {
   const _options = Object.assign({}, defaultOptions, options)
   if (_options.keys instanceof Set) _options.keys = Array.from(_options.keys)
   const { keys, errorResponse, contentType, bearerType, auth, addHook = true, verifyErrorLogLevel = 'error' } = _options
-  
   const inValidLogLevelError = Error('invalid log level')
-  if ( verifyErrorLogLevel == null || ['debug','info','warn','error'].indexOf(verifyErrorLogLevel) < 0 ) throw inValidLogLevelError
+  if (verifyErrorLogLevel == null || ['debug', 'info', 'warn', 'error'].indexOf(verifyErrorLogLevel) < 0) throw inValidLogLevelError
   
   return function verifyBearerAuth (request, reply, done) {
     const header = request.raw.headers.authorization

--- a/plugin.js
+++ b/plugin.js
@@ -22,7 +22,7 @@ function verifyBearerAuthFactory (options) {
     const header = request.raw.headers.authorization
     if (!header) {
       const noHeaderError = Error('missing authorization header')
-      request.log.error('unauthorized: %s', noHeaderError.message)
+      if (addHook) request.log.error('unauthorized: %s', noHeaderError.message)
       if (contentType) reply.header('content-type', contentType)
       reply.code(401)
       if (!addHook) {
@@ -59,7 +59,7 @@ function verifyBearerAuthFactory (options) {
     Promise.resolve(retVal).then((val) => {
       // if val is not truthy return 401
       if (val === false) {
-        request.log.error('unauthorized: %s', invalidKeyError.message)
+        if (addHook) request.log.error('unauthorized: %s', invalidKeyError.message)
         if (contentType) reply.header('content-type', contentType)
         reply.code(401)
         if (!addHook) return done(invalidKeyError)

--- a/plugin.js
+++ b/plugin.js
@@ -17,8 +17,6 @@ function verifyBearerAuthFactory (options) {
   const _options = Object.assign({}, defaultOptions, options)
   if (_options.keys instanceof Set) _options.keys = Array.from(_options.keys)
   const { keys, errorResponse, contentType, bearerType, auth, addHook = true, verifyErrorLogLevel = 'error' } = _options
-  const inValidLogLevelError = Error('invalid log level')
-  if (verifyErrorLogLevel == null || ['debug', 'info', 'warn', 'error'].indexOf(verifyErrorLogLevel) < 0) throw inValidLogLevelError
   
   return function verifyBearerAuth (request, reply, done) {
     const header = request.raw.headers.authorization
@@ -105,8 +103,13 @@ function compare (a, b) {
 }
 
 function plugin (fastify, options, done) {
-  options = Object.assign({ addHook: true }, options)
-
+  options = Object.assign({ addHook: true, verifyErrorLogLevel: 'error' }, options)
+  
+  const invalidLogLevelError = Error('invalid options.verifyErrorLogLevel value')
+  if (typeof options.verifyErrorLogLevel !== 'string'
+      || !Object.prototype.hasOwnProperty.call(fastify.log, options.verifyErrorLogLevel)
+      || (typeof fastify.log[options.verifyErrorLogLevel]) === 'function') throw invalidLogLevelError
+  
   if (options.addHook === true) {
     fastify.addHook('onRequest', verifyBearerAuthFactory(options))
   } else {

--- a/test/decorateWithLogger.test.js
+++ b/test/decorateWithLogger.test.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const tap = require('tap')
+const test = tap.test
+const fastify = require('fastify')({ logger: true })
+const plugin = require('../')
+
+fastify.register(plugin, { addHook: false, keys: new Set(['123456']) })
+
+test('verifyBearerAuth', (t) => {
+  t.plan(1)
+  fastify.ready(() => {
+    t.ok(fastify.verifyBearerAuth)
+  })
+})
+
+test('verifyBearerAuthFactory', (t) => {
+  t.plan(1)
+  fastify.ready(() => {
+    t.ok(fastify.verifyBearerAuthFactory)
+  })
+})
+
+const fastifyLogDebug = require('fastify')({ logger: { level: 'debug' } })
+fastifyLogDebug.register(plugin, { addHook: false, keys: new Set(['123456']), verifyErrorLogLevel: 'debug' })
+
+test('verifyBearerAuth with debug log', (t) => {
+  t.plan(1)
+  fastifyLogDebug.ready(() => {
+    t.ok(fastifyLogDebug.verifyBearerAuth)
+  })
+})
+
+test('verifyBearerAuthFactory with debug log', (t) => {
+  t.plan(1)
+  fastifyLogDebug.ready(() => {
+    t.ok(fastifyLogDebug.verifyBearerAuthFactory)
+  })
+})
+
+const fastifyLogError = require('fastify')({ logger: { level: 'error' } })
+test('register with invalid log level', async (t) => {
+  const invalidLogLevel = 'invalid'
+  t.plan(1)
+  try {
+    await fastifyLogError.register(plugin, { addHook: false, keys: new Set(['123456']), verifyErrorLogLevel: invalidLogLevel })
+  } catch (err) {
+    t.equal(err.message, `fastify.log does not have level '${invalidLogLevel}'`)
+  }
+})

--- a/test/decorateWithLogger.test.js
+++ b/test/decorateWithLogger.test.js
@@ -1,25 +1,8 @@
 'use strict'
 
-const tap = require('tap')
-const test = tap.test
-const fastify = require('fastify')({ logger: true })
-const plugin = require('../')
-
-fastify.register(plugin, { addHook: false, keys: new Set(['123456']) })
-
-test('verifyBearerAuth', (t) => {
-  t.plan(1)
-  fastify.ready(() => {
-    t.ok(fastify.verifyBearerAuth)
-  })
-})
-
-test('verifyBearerAuthFactory', (t) => {
-  t.plan(1)
-  fastify.ready(() => {
-    t.ok(fastify.verifyBearerAuthFactory)
-  })
-})
+const { test } = require('tap')
+const Fastify = require('fastify')
+const plugin = require('..')
 
 test('verifyBearerAuth with debug log', async (t) => {
   t.plan(5)

--- a/test/decorateWithLogger.test.js
+++ b/test/decorateWithLogger.test.js
@@ -21,29 +21,58 @@ test('verifyBearerAuthFactory', (t) => {
   })
 })
 
-const fastifyLogDebug = require('fastify')({ logger: { level: 'debug' } })
-fastifyLogDebug.register(plugin, { addHook: false, keys: new Set(['123456']), verifyErrorLogLevel: 'debug' })
+test('verifyBearerAuth with debug log', async (t) => {
+  t.plan(5)
 
-test('verifyBearerAuth with debug log', (t) => {
-  t.plan(1)
-  fastifyLogDebug.ready(() => {
-    t.ok(fastifyLogDebug.verifyBearerAuth)
+  const logs = []
+  const destination = new stream.Writable({
+    write: function (chunk, encoding, next) {
+      logs.push(JSON.parse(chunk))
+      next()
+    }
   })
+
+  const fastify = Fastify({ logger: { level: 'debug', stream: destination } })
+  await fastify.register(plugin, { addHook: false, keys: new Set(['123456']), verifyErrorLogLevel: 'debug' })
+
+  fastify.get('/', {
+    onRequest: [
+      fastify.verifyBearerAuth
+    ]
+  }, async (request, reply) => {
+    return { message: 'ok' }
+  })
+
+  await fastify.ready()
+
+  t.ok(fastify.verifyBearerAuth)
+  t.ok(fastify.verifyBearerAuthFactory)
+
+  const response = await fastify.inject({
+    method: 'GET',
+    path: '/',
+    headers: {
+      authorization: 'Bearer bad key'
+    }
+  })
+
+  // Debug level is equal to 20 so we search for an entry with a level of 20
+  const failure = logs.find((entry) => entry.level && entry.level === 20)
+
+  t.equal(failure.level, 20)
+  t.equal(failure.msg, 'unauthorized: invalid authorization header')
+
+  t.equal(response.statusCode, 401)
 })
 
-test('verifyBearerAuthFactory with debug log', (t) => {
-  t.plan(1)
-  fastifyLogDebug.ready(() => {
-    t.ok(fastifyLogDebug.verifyBearerAuthFactory)
-  })
-})
-
-const fastifyLogError = require('fastify')({ logger: { level: 'error' } })
 test('register with invalid log level', async (t) => {
-  const invalidLogLevel = 'invalid'
   t.plan(1)
+
+  const invalidLogLevel = 'invalid'
+  const fastify = Fastify({ logger: { level: 'error' } })
+
   try {
-    await fastifyLogError.register(plugin, { addHook: false, keys: new Set(['123456']), verifyErrorLogLevel: invalidLogLevel })
+    await fastify.register(plugin, { addHook: false, keys: new Set(['123456']), verifyErrorLogLevel: invalidLogLevel })
   } catch (err) {
     t.equal(err.message, `fastify.log does not have level '${invalidLogLevel}'`)
   }

--- a/test/decorateWithLogger.test.js
+++ b/test/decorateWithLogger.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { test } = require('tap')
+const stream = require('stream')
 const Fastify = require('fastify')
 const plugin = require('..')
 

--- a/test/plugin.test-d.ts
+++ b/test/plugin.test-d.ts
@@ -35,6 +35,15 @@ expectAssignable<{
   bearerType?: string
 }>(pluginOptionsAuthPromise)
 
+expectAssignable<{
+  keys: Set<string>,
+  auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>,
+  errorResponse?: (err: Error) => { error: string },
+  contentType?: string,
+  bearerType?: string,
+  verifyErrorLogLevel? : string
+}>(pluginOptionsAuthPromise)
+
 fastify().register(bearerAuth, pluginOptions)
 fastify().register(bearerAuth, pluginOptionsAuthPromise)
 


### PR DESCRIPTION
Fix log error when use in multiple authentication -> addHook = false,

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
