### PR TITLE
[TEST] Rename module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "fastify-bearer-auth",
-  "version": "6.2.0",
+  "name": "@fastify/bearer-auth",
+  "version": "7.0.0-rc.1",
   "description": "An authentication plugin for Fastify",
   "main": "plugin.js",
   "types": "plugin.d.ts",


### PR DESCRIPTION
**IGNORE THIS PR: this PR was created while testing the creation of the automation tool.**

This pull request renames the module according to the discussion in
https://github.com/fastify/fastify/issues/3733.

Note that the deprecation module has _already been published_ and that the
code for it does not exist in this repository. The code for the published
deprecation module was generated by https://github.com/fastify/deprecate-modules
and run on @jsumners local system.

Coordinating the drastic changes to the code for the module deprecation and
then restoring the code for the module renaming would have been extremely
difficult and prohibitively tedious.
