### PR TITLE
fix: validate authorization schema

### DIFF
--- a/lib/verifyBearerAuthFactory.js
+++ b/lib/verifyBearerAuthFactory.js
@@ -42,12 +42,12 @@ module.exports = function verifyBearerAuthFactory (options) {
       return authorizationHeaderErrorFn('missing authorization header')
     }
 
-    const key = header.substring(bearerType.length).trim()
     const type = header.substring(0, bearerType.length)
-    if (type.toLowerCase() !== bearerType.toLowerCase()) {
+    if (type !== bearerType) {
       return authorizationHeaderErrorFn('invalid authorization header')
     }
 
+    const key = header.substring(bearerType.length).trim()
     let retVal
     // check if auth function is defined
     if (auth && auth instanceof Function) {

--- a/lib/verifyBearerAuthFactory.js
+++ b/lib/verifyBearerAuthFactory.js
@@ -25,9 +25,8 @@ module.exports = function verifyBearerAuthFactory (options) {
   }
 
   return function verifyBearerAuth (request, reply, done) {
-    const header = request.raw.headers.authorization
-    if (!header) {
-      const noHeaderError = Error('missing authorization header')
+    function authorizationHeaderErrorFn (errorMessage) {
+      const noHeaderError = Error(errorMessage)
       if (verifyErrorLogLevel) request.log[verifyErrorLogLevel]('unauthorized: %s', noHeaderError.message)
       if (contentType) reply.header('content-type', contentType)
       reply.code(401)
@@ -36,10 +35,19 @@ module.exports = function verifyBearerAuthFactory (options) {
         return
       }
       reply.send(errorResponse(noHeaderError))
-      return
+    }
+
+    const header = request.raw.headers.authorization
+    if (!header) {
+      return authorizationHeaderErrorFn('missing authorization header')
     }
 
     const key = header.substring(bearerType.length).trim()
+    const type = header.substring(0, bearerType.length)
+    if (type.toLowerCase() !== bearerType.toLowerCase()) {
+      return authorizationHeaderErrorFn('invalid authorization header')
+    }
+
     let retVal
     // check if auth function is defined
     if (auth && auth instanceof Function) {

--- a/test/verifyBearerAuthFactory.test.js
+++ b/test/verifyBearerAuthFactory.test.js
@@ -55,6 +55,73 @@ test('hook rejects for missing header with custom content type', (t) => {
   hook(request, response)
 })
 
+test('hook rejects for wrong bearer type but same string length as `bearer`', (t) => {
+  t.plan(2)
+
+  const request = {
+    log: { error: noop },
+    raw: { headers: { authorization: `reraeB ${key}` } }
+  }
+  const response = {
+    code: () => response,
+    send
+  }
+
+  function send (body) {
+    t.ok(body.error)
+    t.match(body.error, /invalid authorization header/)
+  }
+
+  const hook = verifyBearerAuthFactory()
+  hook(request, response)
+})
+
+test('hook rejects for wrong bearer type', (t) => {
+  t.plan(2)
+
+  const request = {
+    log: { error: noop },
+    raw: { headers: { authorization: `fake-bearer ${key}` } }
+  }
+  const response = {
+    code: () => response,
+    send
+  }
+
+  function send (body) {
+    t.ok(body.error)
+    t.match(body.error, /invalid authorization header/)
+  }
+
+  const hook = verifyBearerAuthFactory()
+  hook(request, response)
+})
+
+test('hook rejects for wrong alternate Bearer', (t) => {
+  t.plan(2)
+
+  const bearerAlt = 'BearerAlt'
+  const keysAlt = { keys: new Set([key]), bearerType: bearerAlt }
+  const request = {
+    log: { error: noop },
+    raw: {
+      headers: { authorization: `tlAreraeB ${key}` }
+    }
+  }
+  const response = {
+    code: () => response,
+    send
+  }
+
+  function send (body) {
+    t.ok(body.error)
+    t.match(body.error, /invalid authorization header/)
+  }
+
+  const hook = verifyBearerAuthFactory(keysAlt)
+  hook(request, response)
+})
+
 test('hook rejects header without bearer prefix', (t) => {
   t.plan(2)
 

--- a/test/verifyBearerAuthFactory.test.js
+++ b/test/verifyBearerAuthFactory.test.js
@@ -174,7 +174,7 @@ test('hook accepts correct header', (t) => {
   const request = {
     log: { error: noop },
     raw: {
-      headers: { authorization: `bearer ${key}` }
+      headers: { authorization: `Bearer ${key}` }
     }
   }
   const response = {
@@ -224,7 +224,7 @@ test('hook accepts correct header with extra padding', (t) => {
   const request = {
     log: { error: noop },
     raw: {
-      headers: { authorization: `bearer   ${key}   ` }
+      headers: { authorization: `Bearer   ${key}   ` }
     }
   }
   const response = {
@@ -251,7 +251,7 @@ test('hook accepts correct header with auth function (promise)', (t) => {
   const request = {
     log: { error: noop },
     raw: {
-      headers: { authorization: `bearer ${key}` }
+      headers: { authorization: `Bearer ${key}` }
     }
   }
   const response = {
@@ -278,7 +278,7 @@ test('hook accepts correct header with auth function (non-promise)', (t) => {
   const request = {
     log: { error: noop },
     raw: {
-      headers: { authorization: `bearer ${key}` }
+      headers: { authorization: `Bearer ${key}` }
     }
   }
   const response = {
@@ -302,7 +302,7 @@ test('hook rejects wrong token with keys', (t) => {
   const request = {
     log: { error: noop },
     raw: {
-      headers: { authorization: 'bearer abcdedfg' }
+      headers: { authorization: 'Bearer abcdedfg' }
     }
   }
   const response = {
@@ -328,7 +328,7 @@ test('hook rejects wrong token with custom content type', (t) => {
   const request = {
     log: { error: noop },
     raw: {
-      headers: { authorization: 'bearer abcdefg' }
+      headers: { authorization: 'Bearer abcdefg' }
     }
   }
   const response = {
@@ -357,7 +357,7 @@ test('hook rejects wrong token with auth function', (t) => {
   const request = {
     log: { error: noop },
     raw: {
-      headers: { authorization: 'bearer abcdefg' }
+      headers: { authorization: 'Bearer abcdefg' }
     }
   }
 
@@ -397,7 +397,7 @@ test('hook rejects wrong token with function (resolved promise)', (t) => {
   const request = {
     log: { error: noop },
     raw: {
-      headers: { authorization: 'bearer abcdefg' }
+      headers: { authorization: 'Bearer abcdefg' }
     }
   }
   const response = {
@@ -430,7 +430,7 @@ test('hook rejects with 500 when functions fails', (t) => {
   const request = {
     log: { error: noop },
     raw: {
-      headers: { authorization: 'bearer abcdefg' }
+      headers: { authorization: 'Bearer abcdefg' }
     }
   }
   const response = {
@@ -463,7 +463,7 @@ test('hook rejects with 500 when promise rejects', (t) => {
   const request = {
     log: { error: noop },
     raw: {
-      headers: { authorization: 'bearer abcdefg' }
+      headers: { authorization: 'Bearer abcdefg' }
     }
   }
   const response = {
@@ -496,7 +496,7 @@ test('hook rejects with 500 when promise rejects with non Error', (t) => {
   const request = {
     log: { error: noop },
     raw: {
-      headers: { authorization: 'bearer abcdefg' }
+      headers: { authorization: 'Bearer abcdefg' }
     }
   }
   const response = {
@@ -524,7 +524,7 @@ test('hook returns proper error for valid key but failing callback', (t) => {
   const request = {
     log: { error: noop },
     raw: {
-      headers: { authorization: `bearer ${key}` }
+      headers: { authorization: `Bearer ${key}` }
     }
   }
   const response = {
@@ -560,7 +560,7 @@ test('hook rejects with 500 when functions returns non-boolean', (t) => {
   const request = {
     log: { error: noop },
     raw: {
-      headers: { authorization: 'bearer abcdefg' }
+      headers: { authorization: 'Bearer abcdefg' }
     }
   }
   const response = {
@@ -593,7 +593,7 @@ test('hook rejects with 500 when promise resolves to non-boolean', (t) => {
   const request = {
     log: { error: noop },
     raw: {
-      headers: { authorization: 'bearer abcdefg' }
+      headers: { authorization: 'Bearer abcdefg' }
     }
   }
   const response = {
@@ -626,7 +626,7 @@ test('hook rejects with 500 when functions returns non-boolean (addHook: false)'
   const request = {
     log: { error: noop },
     raw: {
-      headers: { authorization: 'bearer abcdefg' }
+      headers: { authorization: 'Bearer abcdefg' }
     }
   }
   const response = {
@@ -654,7 +654,7 @@ test('hook rejects with 500 when promise rejects (addHook: false)', (t) => {
   const request = {
     log: { error: noop },
     raw: {
-      headers: { authorization: 'bearer abcdefg' }
+      headers: { authorization: 'Bearer abcdefg' }
     }
   }
   const response = {


### PR DESCRIPTION
#### Checklist

This PR fixes issue where any string with same length as `bearer` passes validation ex: `AAAAAA auth_key`.
fixes https://github.com/fastify/fastify-bearer-auth/issues/164
 
- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
