### PR TITLE
fix: allow string array as keys option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@ fastify.listen({port: 8000}, (err) => {
 
 ## API
 
-*@fastify/bearer-auth* exports a standard [Fastify plugin][fplugin]. This allows
+*@fastify/bearer-auth* exports a standard [Fastify plugin][plugin]. This allows
 you to register the plugin within scoped paths. Therefore, you could have some
 paths that are not protected by the plugin and others that are. See the [Fastify][fastify]
 documentation and examples for more details.

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const { createError } = require('@fastify/error')
+
+const FST_BEARER_AUTH_INVALID_KEYS_OPTION_TYPE = createError('FST_BEARER_AUTH_INVALID_KEYS_OPTION_TYPE', 'options.keys has to be an Array or a Set')
+const FST_BEARER_AUTH_KEYS_OPTION_INVALID_KEY_TYPE = createError('FST_BEARER_AUTH_KEYS_OPTION_INVALID_KEY_TYPE', 'options.keys has to contain only string entries')
+
+module.exports = {
+  FST_BEARER_AUTH_INVALID_KEYS_OPTION_TYPE,
+  FST_BEARER_AUTH_KEYS_OPTION_INVALID_KEY_TYPE
+}

--- a/lib/verify-bearer-auth-factory.js
+++ b/lib/verify-bearer-auth-factory.js
@@ -1,6 +1,10 @@
 'use strict'
 
 const authenticate = require('./authenticate')
+const {
+  FST_BEARER_AUTH_INVALID_KEYS_OPTION_TYPE,
+  FST_BEARER_AUTH_KEYS_OPTION_INVALID_KEY_TYPE
+} = require('./errors')
 
 const defaultOptions = {
   keys: [],
@@ -14,12 +18,20 @@ const defaultOptions = {
 
 module.exports = function verifyBearerAuthFactory (options) {
   const _options = Object.assign({}, defaultOptions, options)
-  if (_options.keys instanceof Set) _options.keys = Array.from(_options.keys)
+  if (_options.keys instanceof Set) {
+    _options.keys = Array.from(_options.keys)
+  } else if (Array.isArray(_options.keys)) {
+    // create unique array of keys
+    _options.keys = Array.from(new Set(_options.keys))
+  } else {
+    throw new FST_BEARER_AUTH_INVALID_KEYS_OPTION_TYPE()
+  }
+
   const { keys, errorResponse, contentType, bearerType, auth, addHook = true, verifyErrorLogLevel = 'error' } = _options
 
   for (let i = 0, il = keys.length; i < il; ++i) {
     if (typeof keys[i] !== 'string') {
-      throw new Error('options.keys has to contain only string entries')
+      throw new FST_BEARER_AUTH_KEYS_OPTION_INVALID_KEY_TYPE()
     }
     keys[i] = Buffer.from(keys[i])
   }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "tsd": "^0.30.0"
   },
   "dependencies": {
+    "@fastify/error": "^3.4.1",
     "fastify-plugin": "^4.0.0"
   },
   "pre-commit": [

--- a/test/verify-bearer-auth-factory.test.js
+++ b/test/verify-bearer-auth-factory.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('tap').test
-const noop = () => {}
+const noop = () => { }
 const verifyBearerAuthFactory = require('../lib/verify-bearer-auth-factory')
 const key = '123456789012354579814'
 const keys = { keys: new Set([key]) }
@@ -692,4 +692,34 @@ test('hook rejects with 500 when promise rejects (addHook: false)', (t) => {
     t.ok(err)
     t.match(err.message, /failing/)
   })
+})
+
+test('options.keys can be an Array', (t) => {
+  t.plan(1)
+
+  const request = {
+    log: { error: noop },
+    raw: {
+      headers: { authorization: `Bearer ${key}` }
+    }
+  }
+  const response = {
+    code: () => response,
+    send
+  }
+
+  function send (body) {
+    t.fail('should not happen')
+  }
+
+  const hook = verifyBearerAuthFactory({ keys: [key] })
+  hook(request, response, () => {
+    t.pass()
+  })
+})
+
+test('options.keys throws if not an Array and not a Set', (t) => {
+  t.plan(1)
+
+  t.throws(() => verifyBearerAuthFactory({ keys: true }))
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -15,13 +15,13 @@ type FastifyBearerAuth = FastifyPluginCallback<fastifyBearerAuth.FastifyBearerAu
 
 declare namespace fastifyBearerAuth {
   export interface FastifyBearerAuthOptions {
-    keys: Set<string>,
-    auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>,
-    errorResponse?: (err: Error) => { error: string },
-    contentType?: string,
-    bearerType?: string,
-    addHook?: boolean,
-    verifyErrorLogLevel?: string
+    keys: Set<string> | string[];
+    auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>;
+    errorResponse?: (err: Error) => { error: string };
+    contentType?: string;
+    bearerType?: string;
+    addHook?: boolean;
+    verifyErrorLogLevel?: string;
   }
 
   export type verifyBearerAuth = (request: FastifyRequest, reply: FastifyReply, done: (err?: Error) => void) => void

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -28,28 +28,28 @@ const pluginOptionsKeyArray: FastifyBearerAuthOptions = {
 }
 
 expectAssignable<{
-  keys: Set<string>,
-  auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>,
-  errorResponse?: (err: Error) => { error: string },
-  contentType?: string,
-  bearerType?: string
+  keys: Set<string> | string[];
+  auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>;
+  errorResponse?: (err: Error) => { error: string };
+  contentType?: string;
+  bearerType?: string;
 }>(pluginOptions)
 
 expectAssignable<{
-  keys: Set<string>,
-  auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>,
-  errorResponse?: (err: Error) => { error: string },
-  contentType?: string,
-  bearerType?: string
+  keys: Set<string> | string[];
+  auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>;
+  errorResponse?: (err: Error) => { error: string };
+  contentType?: string;
+  bearerType?: string;
 }>(pluginOptionsAuthPromise)
 
 expectAssignable<{
-  keys: Set<string>,
-  auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>,
-  errorResponse?: (err: Error) => { error: string },
-  contentType?: string,
-  bearerType?: string,
-  verifyErrorLogLevel? : string
+  keys: Set<string> | string[];
+  auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>;
+  errorResponse?: (err: Error) => { error: string };
+  contentType?: string;
+  bearerType?: string;
+  verifyErrorLogLevel? : string;
 }>(pluginOptionsAuthPromise)
 
 fastify().register(bearerAuth, pluginOptions)

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -19,6 +19,14 @@ const pluginOptionsAuthPromise: FastifyBearerAuthOptions = {
   bearerType: ''
 }
 
+const pluginOptionsKeyArray: FastifyBearerAuthOptions = {
+  keys: ['foo'],
+  auth: (key: string, req: FastifyRequest) => { return Promise.resolve(true) },
+  errorResponse: (err: Error) => { return { error: err.message } },
+  contentType: '',
+  bearerType: ''
+}
+
 expectAssignable<{
   keys: Set<string>,
   auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>,


### PR DESCRIPTION
According to the readme and the overall implementation it should be possible to pass an array. But typescript types dont allow. Also hardening against errors.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
