### PR TITLE
fix(index): add `preHandler` hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function fastifyBearerAuth (fastify, options, done) {
 
   try {
     if (options.addHook === true) {
-      fastify.addHook('onRequest', verifyBearerAuthFactory(options))
+      fastify.addHook('preHandler', verifyBearerAuthFactory(options))
     } else {
       fastify.decorate('verifyBearerAuthFactory', verifyBearerAuthFactory)
       fastify.decorate('verifyBearerAuth', verifyBearerAuthFactory(options))


### PR DESCRIPTION
The [documentation states](https://github.com/fastify/fastify-bearer-auth/blob/9faf62e1400bf95aa16525ba598e2bc6161e8270/Readme.md?plain=1#L107) that this plugin adds a `preHandler` hook but the code says otherwise.

I noticed this as I was registering  `@fastify/bearer-auth` before `@fastify/cors` (which is an `onRequest` hook) and pre-flight requests were being caught by this plugin, and auth shouldn't be applied to them.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
