### PR TITLE
types(index): allow undefined for some optional properties

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,12 +16,12 @@ type FastifyBearerAuth = FastifyPluginCallback<fastifyBearerAuth.FastifyBearerAu
 declare namespace fastifyBearerAuth {
   export interface FastifyBearerAuthOptions {
     keys: Set<string> | string[];
-    auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>;
+    auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean> | undefined;
     errorResponse?: (err: Error) => { error: string };
-    contentType?: string;
+    contentType?: string | undefined;
     bearerType?: string;
     specCompliance?: 'rfc6749' | 'rfc6750';
-    addHook?: boolean;
+    addHook?: boolean | undefined;
     verifyErrorLogLevel?: string;
   }
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -27,36 +27,54 @@ const pluginOptionsKeyArray: FastifyBearerAuthOptions = {
   bearerType: ''
 }
 
+const pluginOptionsUndefined: FastifyBearerAuthOptions = {
+  keys: ['foo'],
+  auth: undefined,
+  errorResponse: (err: Error) => { return { error: err.message } },
+  contentType: undefined,
+  bearerType: undefined,
+  addHook: undefined
+}
+
 expectAssignable<{
   keys: Set<string> | string[];
-  auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>;
+  auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean> | undefined;
   errorResponse?: (err: Error) => { error: string };
-  contentType?: string;
+  contentType?: string | undefined;
   bearerType?: string;
 }>(pluginOptions)
 
 expectAssignable<{
   keys: Set<string> | string[];
-  auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>;
+  auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean> | undefined;
   errorResponse?: (err: Error) => { error: string };
-  contentType?: string;
+  contentType?: string | undefined;
   bearerType?: string;
-  addHook?: boolean;
+  addHook?: boolean | undefined;
 }>(pluginOptionsKeyArray)
 
 expectAssignable<{
   keys: Set<string> | string[];
-  auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>;
+  auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean> | undefined;
   errorResponse?: (err: Error) => { error: string };
-  contentType?: string;
+  contentType?: string | undefined;
+  bearerType?: string;
+  addHook?: boolean | undefined;
+}>(pluginOptionsUndefined)
+
+expectAssignable<{
+  keys: Set<string> | string[];
+  auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean> | undefined;
+  errorResponse?: (err: Error) => { error: string };
+  contentType?: string | undefined;
   bearerType?: string;
 }>(pluginOptionsAuthPromise)
 
 expectAssignable<{
   keys: Set<string> | string[];
-  auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean>;
+  auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean> | undefined;
   errorResponse?: (err: Error) => { error: string };
-  contentType?: string;
+  contentType?: string | undefined;
   bearerType?: string;
   specCompliance?: 'rfc6749' | 'rfc6750';
   verifyErrorLogLevel?: string;


### PR DESCRIPTION
This PR updates the types of some optional properties to be undefined, because they either default to `undefined` anyway if not set, or they check against undefined:

- [`auth` property defaults to undefined](https://github.com/fastify/fastify-bearer-auth/blob/9faf62e1400bf95aa16525ba598e2bc6161e8270/lib/verify-bearer-auth-factory.js#L19)
- [`contentType` property defaults to undefined](https://github.com/fastify/fastify-bearer-auth/blob/9faf62e1400bf95aa16525ba598e2bc6161e8270/lib/verify-bearer-auth-factory.js#L23)
- [`addHook` performs a typecheck before use](https://github.com/fastify/fastify-bearer-auth/blob/9faf62e1400bf95aa16525ba598e2bc6161e8270/index.js#L29)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
