### PR TITLE
feat: explicit hook configuration via `addHook`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -82,6 +82,7 @@ Defaults to `rfc6750`.
 * `addHook`: If `false`, this plugin will not register `onRequest` hook automatically.
   Instead it provides two decorations: `fastify.verifyBearerAuth` and
    `fastify.verifyBearerAuthFactory`
+* `hook`: Specify the hook to register the plugin, accepts `onRequest` or `preParsing`. Defaults to `onRequest` (optional)
 * `verifyErrorLogLevel`: An optional string specifying the log level for verification errors.
   It must be a valid log level supported by Fastify, or an exception will be thrown when
   registering the plugin. By default, this option is set to `error`
@@ -102,14 +103,14 @@ The default configuration object is:
 }
 ```
 
-The plugin registers a standard Fastify [preHandler hook][prehook] to inspect the request's
+The plugin registers a standard Fastify [onRequest hook][onrequesthook] to inspect the request's
 headers for an `authorization` header in the format `bearer key`. The `key` is matched against
 the configured `keys` object using a [constant time algorithm](https://en.wikipedia.org/wiki/Time_complexity#Constant_time)
 to prevent [timing-attacks](https://snyk.io/blog/node-js-timing-attack-ccc-ctf/). If the
 `authorization` header is missing, malformed, or the `key` does not validate, a 401 response
 is sent with a `{error: message}` body, and no further request processing is performed.
 
-[prehook]: https://github.com/fastify/fastify/blob/main/docs/Reference/Hooks.md
+[onrequesthook]: https://github.com/fastify/fastify/blob/main/docs/Reference/Hooks.md#onrequest
 
 ## Integration with `@fastify/auth`
 

--- a/Readme.md
+++ b/Readme.md
@@ -79,10 +79,10 @@ Defaults to `rfc6750`.
   to one of these values. If the function returns or resolves to any other value, rejects, or throws,
   an HTTP status of `500` will be sent. `req` is the Fastify request object. If `auth` is a function,
   `keys` will be ignored. If `auth` is not a function or `undefined`, `keys` will be used
-* `addHook`: If `false`, this plugin will not register `onRequest` hook automatically.
-  Instead it provides two decorations: `fastify.verifyBearerAuth` and
-   `fastify.verifyBearerAuthFactory`
-* `hook`: Specify the hook to register the plugin, accepts `onRequest` or `preParsing`. Defaults to `onRequest` (optional)
+* `addHook`: If `false`, this plugin will not register any hook automatically. Instead, it provides two decorations: `fastify.verifyBearerAuth` and
+  `fastify.verifyBearerAuthFactory`. If `true` or nullish, it will default to `onRequest`. You can also specify `onRequest` or `preParsing` to register the respective hook
+* `addHook`: If `false`, no hook is registered automatically, and instead the `fastify.verifyBearerAuth` and `fastify.verifyBearerAuthFactory` decorators are exposed. If `true` or 
+  nullish, defaults to `onRequest`. `onRequest` or `preParsing` can also be used to register the respective hook
 * `verifyErrorLogLevel`: An optional string specifying the log level for verification errors.
   It must be a valid log level supported by Fastify, or an exception will be thrown when
   registering the plugin. By default, this option is set to `error`

--- a/Readme.md
+++ b/Readme.md
@@ -79,10 +79,8 @@ Defaults to `rfc6750`.
   to one of these values. If the function returns or resolves to any other value, rejects, or throws,
   an HTTP status of `500` will be sent. `req` is the Fastify request object. If `auth` is a function,
   `keys` will be ignored. If `auth` is not a function or `undefined`, `keys` will be used
-* `addHook`: If `false`, this plugin will not register any hook automatically. Instead, it provides two decorations: `fastify.verifyBearerAuth` and
-  `fastify.verifyBearerAuthFactory`. If `true` or nullish, it will default to `onRequest`. You can also specify `onRequest` or `preParsing` to register the respective hook
-* `addHook`: If `false`, no hook is registered automatically, and instead the `fastify.verifyBearerAuth` and `fastify.verifyBearerAuthFactory` decorators are exposed. If `true` or 
-  nullish, defaults to `onRequest`. `onRequest` or `preParsing` can also be used to register the respective hook
+* `addHook`: If `false`, no hook is registered automatically, and instead the `fastify.verifyBearerAuth` and `fastify.verifyBearerAuthFactory` decorators are exposed.
+  If `true` or nullish, defaults to `onRequest`. `onRequest` or `preParsing` can also be used to register the respective hook
 * `verifyErrorLogLevel`: An optional string specifying the log level for verification errors.
   It must be a valid log level supported by Fastify, or an exception will be thrown when
   registering the plugin. By default, this option is set to `error`

--- a/Readme.md
+++ b/Readme.md
@@ -79,8 +79,10 @@ Defaults to `rfc6750`.
   to one of these values. If the function returns or resolves to any other value, rejects, or throws,
   an HTTP status of `500` will be sent. `req` is the Fastify request object. If `auth` is a function,
   `keys` will be ignored. If `auth` is not a function or `undefined`, `keys` will be used
-* `addHook`: If `false`, no hook is registered automatically, and instead the `fastify.verifyBearerAuth` and `fastify.verifyBearerAuthFactory` decorators are exposed.
-  If `true` or nullish, defaults to `onRequest`. `onRequest` or `preParsing` can also be used to register the respective hook
+* `addHook`: Accepts a boolean, `'onRequest'`, or `'preParsing'` (optional, defaults to `'onRequest'`):
+  * `true` registers an `onRequest` hook
+  * `'onRequest'` and `'preParsing'` registers their respective hooks
+  * `false` will not register a hook, and the `fastify.verifyBearerAuth` and `fastify.verifyBearerAuthFactory` decorators will be exposed
 * `verifyErrorLogLevel`: An optional string specifying the log level for verification errors.
   It must be a valid log level supported by Fastify, or an exception will be thrown when
   registering the plugin. By default, this option is set to `error`

--- a/index.js
+++ b/index.js
@@ -4,6 +4,10 @@ const fp = require('fastify-plugin')
 const verifyBearerAuthFactory = require('./lib/verify-bearer-auth-factory')
 const { FST_BEARER_AUTH_INVALID_HOOK, FST_BEARER_AUTH_INVALID_LOG_LEVEL } = require('./lib/errors')
 
+/**
+ * Hook type limited to 'onRequest' and 'preParsing' to protect against DoS attacks.
+ * @see {@link https://github.com/fastify/fastify-auth?tab=readme-ov-file#hook-selection | fastify-auth hook selection}
+ */
 const validHooks = new Set(['onRequest', 'preParsing'])
 
 function fastifyBearerAuth (fastify, options, done) {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,10 @@ const { FST_BEARER_AUTH_INVALID_HOOK, FST_BEARER_AUTH_INVALID_LOG_LEVEL } = requ
 const validHooks = new Set(['onRequest', 'preParsing'])
 
 function fastifyBearerAuth (fastify, options, done) {
-  options = { addHook: true, verifyErrorLogLevel: 'error', ...options }
+  options = { verifyErrorLogLevel: 'error', ...options }
+  if (options.addHook === true || options.addHook == null) {
+    options.addHook = 'onRequest'
+  }
 
   if (
     Object.hasOwn(fastify.log, 'error') === false ||
@@ -32,19 +35,18 @@ function fastifyBearerAuth (fastify, options, done) {
   }
 
   try {
-    if (options.addHook === true) {
-      options.hook ||= 'onRequest'
-      if (!validHooks.has(options.hook)) {
+    if (options.addHook) {
+      if (!validHooks.has(options.addHook)) {
         done(new FST_BEARER_AUTH_INVALID_HOOK())
       }
 
-      if (options.hook === 'preParsing') {
+      if (options.addHook === 'preParsing') {
         const verifyBearerAuth = verifyBearerAuthFactory(options)
         fastify.addHook('preParsing', (request, reply, _payload, done) => {
           verifyBearerAuth(request, reply, done)
         })
       } else {
-        fastify.addHook(options.hook, verifyBearerAuthFactory(options))
+        fastify.addHook(options.addHook, verifyBearerAuthFactory(options))
       }
     } else {
       fastify.decorate('verifyBearerAuthFactory', verifyBearerAuthFactory)

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -3,6 +3,7 @@
 const { createError } = require('@fastify/error')
 
 const FST_BEARER_AUTH_INVALID_KEYS_OPTION_TYPE = createError('FST_BEARER_AUTH_INVALID_KEYS_OPTION_TYPE', 'options.keys has to be an Array or a Set')
+const FST_BEARER_AUTH_INVALID_HOOK = createError('FST_BEARER_AUTH_INVALID_HOOK', 'options.hook must be either "onRequest" or "preParsing"')
 const FST_BEARER_AUTH_INVALID_LOG_LEVEL = createError('FST_BEARER_AUTH_INVALID_LOG_LEVEL', 'fastify.log does not have level \'%s\'')
 const FST_BEARER_AUTH_KEYS_OPTION_INVALID_KEY_TYPE = createError('FST_BEARER_AUTH_KEYS_OPTION_INVALID_KEY_TYPE', 'options.keys has to contain only string entries')
 const FST_BEARER_AUTH_INVALID_SPEC = createError('FST_BEARER_AUTH_INVALID_SPEC', 'options.specCompliance has to be set to \'rfc6750\' or \'rfc6749\'')
@@ -11,6 +12,7 @@ const FST_BEARER_AUTH_INVALID_AUTHORIZATION_HEADER = createError('FST_BEARER_AUT
 
 module.exports = {
   FST_BEARER_AUTH_INVALID_KEYS_OPTION_TYPE,
+  FST_BEARER_AUTH_INVALID_HOOK,
   FST_BEARER_AUTH_INVALID_LOG_LEVEL,
   FST_BEARER_AUTH_KEYS_OPTION_INVALID_KEY_TYPE,
   FST_BEARER_AUTH_INVALID_SPEC,

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -3,7 +3,7 @@
 const { createError } = require('@fastify/error')
 
 const FST_BEARER_AUTH_INVALID_KEYS_OPTION_TYPE = createError('FST_BEARER_AUTH_INVALID_KEYS_OPTION_TYPE', 'options.keys has to be an Array or a Set')
-const FST_BEARER_AUTH_INVALID_HOOK = createError('FST_BEARER_AUTH_INVALID_HOOK', 'options.hook must be either "onRequest" or "preParsing"')
+const FST_BEARER_AUTH_INVALID_HOOK = createError('FST_BEARER_AUTH_INVALID_HOOK', 'options.addHook must be either "onRequest" or "preParsing"')
 const FST_BEARER_AUTH_INVALID_LOG_LEVEL = createError('FST_BEARER_AUTH_INVALID_LOG_LEVEL', 'fastify.log does not have level \'%s\'')
 const FST_BEARER_AUTH_KEYS_OPTION_INVALID_KEY_TYPE = createError('FST_BEARER_AUTH_KEYS_OPTION_INVALID_KEY_TYPE', 'options.keys has to contain only string entries')
 const FST_BEARER_AUTH_INVALID_SPEC = createError('FST_BEARER_AUTH_INVALID_SPEC', 'options.specCompliance has to be set to \'rfc6750\' or \'rfc6749\'')

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -8,7 +8,7 @@ const plugin = require('../')
 const keys = new Set(['123456'])
 const authorization = 'Bearer 123456'
 
-test('onrequest hook used by default', async (t) => {
+test('onRequest hook used by default', async (t) => {
   t.plan(9)
   const fastify = Fastify()
   fastify.register(plugin, { keys, addHook: undefined }).get('/test', (_req, res) => {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -11,7 +11,7 @@ const authorization = 'Bearer 123456'
 test('onrequest hook used by default', async (t) => {
   t.plan(9)
   const fastify = Fastify()
-  fastify.register(plugin, { keys, hook: undefined }).get('/test', (_req, res) => {
+  fastify.register(plugin, { keys, addHook: undefined }).get('/test', (_req, res) => {
     res.send({ hello: 'world' })
   })
 
@@ -40,7 +40,7 @@ test('onrequest hook used by default', async (t) => {
 test('preParsing hook used when specified', async (t) => {
   t.plan(9)
   const fastify = Fastify()
-  fastify.register(plugin, { keys, hook: 'preParsing' }).get('/test', (_req, res) => {
+  fastify.register(plugin, { keys, addHook: 'preParsing' }).get('/test', (_req, res) => {
     res.send({ hello: 'world' })
   })
 
@@ -69,7 +69,7 @@ test('preParsing hook used when specified', async (t) => {
 test('onrequest hook used when specified', async (t) => {
   t.plan(9)
   const fastify = Fastify()
-  fastify.register(plugin, { keys, hook: 'onRequest' }).get('/test', (_req, res) => {
+  fastify.register(plugin, { keys, addHook: 'onRequest' }).get('/test', (_req, res) => {
     res.send({ hello: 'world' })
   })
 
@@ -99,8 +99,8 @@ test('error when invalid hook specified', async (t) => {
   t.plan(1)
   const fastify = Fastify()
   try {
-    await fastify.register(plugin, { keys, hook: 'onResponse' })
+    await fastify.register(plugin, { keys, addHook: 'onResponse' })
   } catch (err) {
-    t.assert.strictEqual(err.message, 'options.hook must be either "onRequest" or "preParsing"')
+    t.assert.strictEqual(err.message, 'options.addHook must be either "onRequest" or "preParsing"')
   }
 })

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -1,0 +1,106 @@
+'use strict'
+
+const { test } = require('node:test')
+const Fastify = require('fastify')
+const kFastifyContext = require('fastify/lib/symbols').kRouteContext
+const plugin = require('../')
+
+const keys = new Set(['123456'])
+const authorization = 'Bearer 123456'
+
+test('onrequest hook used by default', async (t) => {
+  t.plan(9)
+  const fastify = Fastify()
+  fastify.register(plugin, { keys, hook: undefined }).get('/test', (_req, res) => {
+    res.send({ hello: 'world' })
+  })
+
+  fastify.addHook('onResponse', (request, _reply, done) => {
+    t.assert.strictEqual(request[kFastifyContext].onError, null)
+    t.assert.strictEqual(request[kFastifyContext].onRequest.length, 1)
+    t.assert.strictEqual(request[kFastifyContext].onSend, null)
+    t.assert.strictEqual(request[kFastifyContext].preHandler, null)
+    t.assert.strictEqual(request[kFastifyContext].preParsing, null)
+    t.assert.strictEqual(request[kFastifyContext].preSerialization, null)
+    t.assert.strictEqual(request[kFastifyContext].preValidation, null)
+    done()
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/test',
+    headers: {
+      authorization
+    }
+  })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.body), { hello: 'world' })
+})
+
+test('preParsing hook used when specified', async (t) => {
+  t.plan(9)
+  const fastify = Fastify()
+  fastify.register(plugin, { keys, hook: 'preParsing' }).get('/test', (_req, res) => {
+    res.send({ hello: 'world' })
+  })
+
+  fastify.addHook('onResponse', (request, _reply, done) => {
+    t.assert.strictEqual(request[kFastifyContext].onError, null)
+    t.assert.strictEqual(request[kFastifyContext].onRequest, null)
+    t.assert.strictEqual(request[kFastifyContext].onSend, null)
+    t.assert.strictEqual(request[kFastifyContext].preHandler, null)
+    t.assert.strictEqual(request[kFastifyContext].preParsing.length, 1)
+    t.assert.strictEqual(request[kFastifyContext].preSerialization, null)
+    t.assert.strictEqual(request[kFastifyContext].preValidation, null)
+    done()
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/test',
+    headers: {
+      authorization
+    }
+  })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.body), { hello: 'world' })
+})
+
+test('onrequest hook used when specified', async (t) => {
+  t.plan(9)
+  const fastify = Fastify()
+  fastify.register(plugin, { keys, hook: 'onRequest' }).get('/test', (_req, res) => {
+    res.send({ hello: 'world' })
+  })
+
+  fastify.addHook('onResponse', (request, _reply, done) => {
+    t.assert.strictEqual(request[kFastifyContext].onError, null)
+    t.assert.strictEqual(request[kFastifyContext].onRequest.length, 1)
+    t.assert.strictEqual(request[kFastifyContext].onSend, null)
+    t.assert.strictEqual(request[kFastifyContext].preHandler, null)
+    t.assert.strictEqual(request[kFastifyContext].preParsing, null)
+    t.assert.strictEqual(request[kFastifyContext].preSerialization, null)
+    t.assert.strictEqual(request[kFastifyContext].preValidation, null)
+    done()
+  })
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/test',
+    headers: {
+      authorization
+    }
+  })
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.deepStrictEqual(JSON.parse(response.body), { hello: 'world' })
+})
+
+test('error when invalid hook specified', async (t) => {
+  t.plan(1)
+  const fastify = Fastify()
+  try {
+    await fastify.register(plugin, { keys, hook: 'onResponse' })
+  } catch (err) {
+    t.assert.strictEqual(err.message, 'options.hook must be either "onRequest" or "preParsing"')
+  }
+})

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -66,7 +66,7 @@ test('preParsing hook used when specified', async (t) => {
   t.assert.deepStrictEqual(JSON.parse(response.body), { hello: 'world' })
 })
 
-test('onrequest hook used when specified', async (t) => {
+test('onRequest hook used when specified', async (t) => {
   t.plan(9)
   const fastify = Fastify()
   fastify.register(plugin, { keys, addHook: 'onRequest' }).get('/test', (_req, res) => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,8 +21,7 @@ declare namespace fastifyBearerAuth {
     contentType?: string | undefined;
     bearerType?: string;
     specCompliance?: 'rfc6749' | 'rfc6750';
-    addHook?: boolean | undefined;
-    hook?: 'onRequest' | 'preParsing' | undefined;
+    addHook?: boolean | 'onRequest' | 'preParsing' | undefined;
     verifyErrorLogLevel?: string;
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,6 +22,7 @@ declare namespace fastifyBearerAuth {
     bearerType?: string;
     specCompliance?: 'rfc6749' | 'rfc6750';
     addHook?: boolean | undefined;
+    hook?: 'onRequest' | 'preParsing' | undefined;
     verifyErrorLogLevel?: string;
   }
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -16,7 +16,8 @@ const pluginOptionsAuthPromise: FastifyBearerAuthOptions = {
   auth: (_key: string, _req: FastifyRequest) => { return Promise.resolve(true) },
   errorResponse: (err: Error) => { return { error: err.message } },
   contentType: '',
-  bearerType: ''
+  bearerType: '',
+  hook: 'onRequest'
 }
 
 const pluginOptionsKeyArray: FastifyBearerAuthOptions = {
@@ -33,7 +34,8 @@ const pluginOptionsUndefined: FastifyBearerAuthOptions = {
   errorResponse: (err: Error) => { return { error: err.message } },
   contentType: undefined,
   bearerType: undefined,
-  addHook: undefined
+  addHook: undefined,
+  hook: undefined
 }
 
 expectAssignable<{
@@ -60,6 +62,7 @@ expectAssignable<{
   contentType?: string | undefined;
   bearerType?: string;
   addHook?: boolean | undefined;
+  hook?: 'onRequest' | 'preParsing' | undefined;
 }>(pluginOptionsUndefined)
 
 expectAssignable<{

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -17,7 +17,7 @@ const pluginOptionsAuthPromise: FastifyBearerAuthOptions = {
   errorResponse: (err: Error) => { return { error: err.message } },
   contentType: '',
   bearerType: '',
-  hook: 'onRequest'
+  addHook: 'onRequest'
 }
 
 const pluginOptionsKeyArray: FastifyBearerAuthOptions = {
@@ -34,8 +34,7 @@ const pluginOptionsUndefined: FastifyBearerAuthOptions = {
   errorResponse: (err: Error) => { return { error: err.message } },
   contentType: undefined,
   bearerType: undefined,
-  addHook: undefined,
-  hook: undefined
+  addHook: undefined
 }
 
 expectAssignable<{
@@ -52,7 +51,7 @@ expectAssignable<{
   errorResponse?: (err: Error) => { error: string };
   contentType?: string | undefined;
   bearerType?: string;
-  addHook?: boolean | undefined;
+  addHook?: boolean | 'onRequest' | 'preParsing' | undefined;
 }>(pluginOptionsKeyArray)
 
 expectAssignable<{
@@ -61,8 +60,7 @@ expectAssignable<{
   errorResponse?: (err: Error) => { error: string };
   contentType?: string | undefined;
   bearerType?: string;
-  addHook?: boolean | undefined;
-  hook?: 'onRequest' | 'preParsing' | undefined;
+  addHook?: boolean | 'onRequest' | 'preParsing' | undefined;
 }>(pluginOptionsUndefined)
 
 expectAssignable<{


### PR DESCRIPTION
Supersedes #207.

This PR updates the `addHook` option to allow the hook type to be explicitly configured to be either `onRequest` or `preParsing`.
The hooks are limited to these two values so that developers [cannot open themselves up to DoS attacks](https://github.com/fastify/fastify-auth?tab=readme-ov-file#hook-selection).
If the option is nullish or true it defaults to `onRequest`, which is its original functionality.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
