### PR TITLE
Allow any return value for error

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,7 +28,7 @@ declare namespace fastifyBearerAuth {
   export interface FastifyBearerAuthOptions {
     keys: Set<string> | string[];
     auth?: (key: string, req: FastifyRequest) => boolean | Promise<boolean> | undefined;
-    errorResponse?: (err: Error) => { error: string };
+    errorResponse?: (err: Error) => unknown;
     contentType?: string | undefined;
     bearerType?: string;
     specCompliance?: 'rfc6749' | 'rfc6750';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

#### Description

The return value of the `errorResponse` config option function gets passed directly to `reply.send` and as such can support a wide range of possible values. Since the documentation encourages using this option to supply one's own error shape, it shouldn't make assumptions about the type, so I've set it to `unknown` in order to fix the type error I get when supplying my own error shape.