### PR TITLE
fix(auth): avoid mutating `options` param in `fastifyBearerAuth`

### DIFF
--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -23,17 +23,14 @@ test('success route succeeds', async (t) => {
   t.assert.deepStrictEqual(JSON.parse(response.body), { hello: 'world' })
 })
 
-test('registering plugin should not mutate options', (t, done) => {
-  t.plan(2)
+test('registering plugin should not mutate options', async (t) => {
+  t.plan(1)
   const fastify = require('fastify')()
   const options = {}
   fastify.register(plugin, options)
 
-  fastify.ready((err) => {
-    t.assert.ifError(err)
-    t.assert.strictEqual(options.defaultRelation, undefined)
-    done()
-  })
+  await fastify.ready()
+  t.assert.strictEqual(options.defaultRelation, undefined)
 })
 
 test('invalid key route fails correctly', async (t) => {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -23,6 +23,19 @@ test('success route succeeds', async (t) => {
   t.assert.deepStrictEqual(JSON.parse(response.body), { hello: 'world' })
 })
 
+test('registering plugin should not mutate options', (t, done) => {
+  t.plan(2)
+  const fastify = require('fastify')()
+  const options = {}
+  fastify.register(plugin, options)
+
+  fastify.ready((err) => {
+    t.assert.ifError(err)
+    t.assert.strictEqual(options.defaultRelation, undefined)
+    done()
+  })
+})
+
 test('invalid key route fails correctly', async (t) => {
   t.plan(2)
   const response = await fastify.inject({


### PR DESCRIPTION
Same issue as https://github.com/fastify/fastify-auth/pull/270

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
